### PR TITLE
Updated required ruby version to be compatible with decidim@0.21

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
   RSpec:
     Patterns:

--- a/decidim-action_delegator.gemspec
+++ b/decidim-action_delegator.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = ["saulopefa@gmail.com", "ivan@platoniq.net"]
   s.license = "AGPL-3.0"
   s.homepage = "https://github.com/coopdevs/decidim-module-action_delegator"
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.5"
 
   s.name = "decidim-action_delegator"
   s.summary = "A Decidim ActionDelegator module"


### PR DESCRIPTION
![Screen Shot 2020-09-16 at 08 48 29](https://user-images.githubusercontent.com/935744/93301912-0b7ad600-f7f1-11ea-98d3-b91e776087f6.png)

Fixing ruby dependencies when setting up decidim's development_app and using decidim@0.21 + the action_delegator module.