### PR TITLE
Fix self delegation and added errors in form

### DIFF
--- a/app/commands/decidim/action_delegator/admin/create_delegation.rb
+++ b/app/commands/decidim/action_delegator/admin/create_delegation.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    module Admin
+      class CreateDelegation < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form         - A form object with the params.
+        # delegated_by - The user performing the operation
+        def initialize(form, current_setting, performed_by)
+          @form = form
+          @current_setting = current_setting
+          @performed_by = performed_by
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid? || self_delegate?
+
+          create_delegation
+
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :form, :performed_by, :current_setting
+
+        def self_delegate?
+          return false unless performed_by.id == form.grantee_id
+
+          form.errors.add(:grantee_id, :self_delegate)
+          true
+        end
+
+        def create_delegation
+          attributes = form.attributes.merge(setting: current_setting)
+          Delegation.new(attributes)
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/action_delegator/admin/create_delegation.rb
+++ b/app/commands/decidim/action_delegator/admin/create_delegation.rb
@@ -8,9 +8,8 @@ module Decidim
         #
         # form         - A form object with the params.
         # delegated_by - The user performing the operation
-        def initialize(form, current_setting, performed_by)
+        def initialize(form, performed_by)
           @form = form
-          @current_setting = current_setting
           @performed_by = performed_by
         end
 
@@ -30,7 +29,7 @@ module Decidim
 
         private
 
-        attr_reader :form, :performed_by, :current_setting
+        attr_reader :form, :performed_by
 
         def self_delegate?
           return false unless performed_by.id == form.grantee_id
@@ -40,8 +39,7 @@ module Decidim
         end
 
         def create_delegation!
-          attributes = form.attributes.merge(setting: current_setting)
-          Delegation.create!(attributes)
+          Delegation.create!(form.attributes)
         end
       end
     end

--- a/app/commands/decidim/action_delegator/admin/create_delegation.rb
+++ b/app/commands/decidim/action_delegator/admin/create_delegation.rb
@@ -23,7 +23,7 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid? || self_delegate?
 
-          create_delegation
+          create_delegation!
 
           broadcast(:ok)
         end
@@ -39,9 +39,9 @@ module Decidim
           true
         end
 
-        def create_delegation
+        def create_delegation!
           attributes = form.attributes.merge(setting: current_setting)
-          Delegation.new(attributes)
+          Delegation.create!(attributes)
         end
       end
     end

--- a/app/controllers/decidim/action_delegator/admin/delegations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/delegations_controller.rb
@@ -29,9 +29,9 @@ module Decidim
         def create
           enforce_permission_to :create, :delegation
 
-          @form = form(DelegationForm).from_params(params)
+          @form = form(DelegationForm).from_params(params.merge(setting: current_setting))
 
-          CreateDelegation.call(@form, current_setting, current_user) do
+          CreateDelegation.call(@form, current_user) do
             on(:ok) do
               notice = I18n.t("delegations.create.success", scope: "decidim.action_delegator.admin")
               redirect_to setting_delegations_path(current_setting), notice: notice

--- a/app/controllers/decidim/action_delegator/admin/delegations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/delegations_controller.rb
@@ -34,7 +34,7 @@ module Decidim
           CreateDelegation.call(@form, current_setting, current_user) do
             on(:ok) do
               notice = I18n.t("delegations.create.success", scope: "decidim.action_delegator.admin")
-              redirect_to setting_delegations_path(@delegation.setting), notice: notice
+              redirect_to setting_delegations_path(current_setting), notice: notice
             end
 
             on(:invalid) do

--- a/app/forms/decidim/action_delegator/admin/delegation_form.rb
+++ b/app/forms/decidim/action_delegator/admin/delegation_form.rb
@@ -8,9 +8,11 @@ module Decidim
       class DelegationForm < Form
         attribute :granter_id, Integer
         attribute :grantee_id, Integer
+        attribute :setting, Setting
 
         validates :granter_id, presence: true
         validates :grantee_id, presence: true
+        validates :setting, presence: true
 
         def granter
           User.find_by(id: granter_id)

--- a/app/forms/decidim/action_delegator/admin/delegation_form.rb
+++ b/app/forms/decidim/action_delegator/admin/delegation_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    module Admin
+      # A form object used to create a Delegation
+      #
+      class DelegationForm < Form
+        attribute :granter_id, Integer
+        attribute :grantee_id, Integer
+
+        validates :granter_id, presence: true
+        validates :grantee_id, presence: true
+
+        def granter
+          User.find_by(id: granter_id)
+        end
+
+        def grantee
+          User.find_by(id: grantee_id)
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/action_delegator/admin/delegations/new.html.erb
+++ b/app/views/decidim/action_delegator/admin/delegations/new.html.erb
@@ -2,7 +2,7 @@
   <%= t ".title" %>
 </h2>
 
-<%= form_for @delegation, url: { action: "create" }, html: { class: "form new_delegation" } do |f| %>
+<%= decidim_form_for @form, url: { action: "create" }, html: { class: "form new_delegation" } do |f| %>
   <div class="card">
     <div class="card-divider">
       <h2 class="card-title"><%= t ".form.title" %></h2>
@@ -12,12 +12,12 @@
       <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t('.select_member') } %>
 
       <div class="row column">
-        <%= f.autocomplete_select(:granter_id, @delegation.granter_id,  { multiple: false, label: t('.granter') }, prompt_options) do |user|
+        <%= f.autocomplete_select(:granter_id, @form.granter,  { multiple: false, label: t('.granter') }, prompt_options) do |user|
           { value: user.id, label: "#{user.name} (@#{user.nickname})" }
         end %>
       </div>
       <div class="row column">
-        <%= f.autocomplete_select(:grantee_id, @delegation.grantee_id,  { multiple: false, label: t('.grantee') }, prompt_options) do |user|
+        <%= f.autocomplete_select(:grantee_id, @form.grantee,  { multiple: false, label: t('.grantee') }, prompt_options) do |user|
           { value: user.id, label: "#{user.name} (@#{user.nickname})" }
         end %>
       </div>

--- a/app/views/decidim/action_delegator/admin/delegations/new.html.erb
+++ b/app/views/decidim/action_delegator/admin/delegations/new.html.erb
@@ -9,15 +9,15 @@
     </div>
 
     <div class="card-section">
-      <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t('.select_member') } %>
+      <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t(".select_member") } %>
 
       <div class="row column">
-        <%= f.autocomplete_select(:granter_id, @form.granter,  { multiple: false, label: t('.granter') }, prompt_options) do |user|
+        <%= f.autocomplete_select(:granter_id, @form.granter,  { multiple: false, label: t(".granter") }, prompt_options) do |user|
           { value: user.id, label: "#{user.name} (@#{user.nickname})" }
         end %>
       </div>
       <div class="row column">
-        <%= f.autocomplete_select(:grantee_id, @form.grantee,  { multiple: false, label: t('.grantee') }, prompt_options) do |user|
+        <%= f.autocomplete_select(:grantee_id, @form.grantee,  { multiple: false, label: t(".grantee") }, prompt_options) do |user|
           { value: user.id, label: "#{user.name} (@#{user.nickname})" }
         end %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,12 @@
 ---
 en:
+  activemodel:
+    errors:
+      models:
+        delegation:
+          attributes:
+            grantee_id:
+              self_delegate: You can't delegate to yourself
   decidim:
     action_delegator:
       admin:

--- a/spec/commands/decidim/action_delegator/admin/create_delegation_spec.rb
+++ b/spec/commands/decidim/action_delegator/admin/create_delegation_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::Admin::CreateDelegation do
+  subject { described_class.new(form, current_setting, current_user) }
+
+  let(:current_user) { create(:user, organization: organization) }
+  let(:current_setting) { create(:setting) }
+  let(:organization) { create(:organization) }
+  let(:granter) { create(:user, organization: organization) }
+  let(:grantee) { create(:user, organization: organization) }
+
+  let(:form) do
+    double(
+      invalid?: invalid,
+      grantee_id: grantee.id,
+      granter_id: granter.id,
+      attributes: {
+        grantee_id: grantee.id,
+        granter_id: granter.id
+      },
+      errors: double(add: true)
+    )
+  end
+
+  let(:invalid) { false }
+
+  context "when form is valid" do
+    context "when current_user is not the granter" do
+      it "broadcasts :ok" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+    end
+
+    context "when current_user self delegates" do
+      let(:grantee) { current_user }
+
+      it "broadcasts :invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+  end
+
+  context "when form is invalid" do
+    let(:invalid) { true }
+
+    it "broadcasts :invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+end

--- a/spec/commands/decidim/action_delegator/admin/create_delegation_spec.rb
+++ b/spec/commands/decidim/action_delegator/admin/create_delegation_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::ActionDelegator::Admin::CreateDelegation do
-  subject { described_class.new(form, current_setting, current_user) }
+  subject { described_class.new(form, current_user) }
 
   let(:current_user) { create(:user, organization: organization) }
   let(:current_setting) { create(:setting) }
@@ -18,7 +18,8 @@ describe Decidim::ActionDelegator::Admin::CreateDelegation do
       granter_id: granter.id,
       attributes: {
         grantee_id: grantee.id,
-        granter_id: granter.id
+        granter_id: granter.id,
+        setting: current_setting
       },
       errors: double(add: true)
     )

--- a/spec/forms/decidim/action_delegator/admin/delegation_form_spec.rb
+++ b/spec/forms/decidim/action_delegator/admin/delegation_form_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 describe Decidim::ActionDelegator::Admin::DelegationForm do
   subject { described_class.from_params(attributes) }
 
-  let(:attributes) { { granter_id: granter.id, grantee_id: grantee.id } }
+  let(:attributes) { { granter_id: granter.id, grantee_id: grantee.id, setting: current_setting } }
+  let(:current_setting) { create(:setting) }
   let(:organization) { create(:organization) }
   let(:granter) { create(:user, organization: organization) }
   let(:grantee) { create(:user, organization: organization) }

--- a/spec/forms/decidim/action_delegator/admin/delegation_form_spec.rb
+++ b/spec/forms/decidim/action_delegator/admin/delegation_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::Admin::DelegationForm do
+  subject { described_class.from_params(attributes) }
+
+  let(:attributes) { { granter_id: granter.id, grantee_id: grantee.id } }
+  let(:organization) { create(:organization) }
+  let(:granter) { create(:user, organization: organization) }
+  let(:grantee) { create(:user, organization: organization) }
+
+  context "when there's granter and grantee" do
+    it { is_expected.to be_valid }
+  end
+
+  context "when granter is missing" do
+    let(:attributes) { { granter_id: nil, grantee_id: grantee.id } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when grantee is missing" do
+    let(:attributes) { { granter_id: granter.id, grantee_id: nil } }
+
+    it { is_expected.not_to be_valid }
+  end
+end


### PR DESCRIPTION
Adds form errors when creating a Delegation. Also prevents admins delegating votes to themselves. Fixes https://github.com/coopdevs/decidim-module-action_delegator/issues/12.

![](http://g.recordit.co/ytocfsNkhd.gif)