### PR TITLE
Results by membership type and weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ ActionDelegator does not provides new Components or Participatory Spaces but enh
 
 ### Extended consultation results
 
-This gem modifies the consultation's results page adding two extra columns `Membership type` and `Membership weight`. This requires a Decidim verification that creates `decidim_authorizations` records which include the following JSON structure in the `metadata` column:
+This gem modifies the consultation's results page adding two extra columns
+`Membership type` and `Membership weight`. This requires a Decidim verification
+that creates `decidim_authorizations` records which include the following JSON
+structure in the `metadata` column:
 
 ```json
 "{ metadata_type: '',   metadata_weight: '' }"
 ```
 
-See https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/2 as an example of such verification.
+See https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/2
+as an example of such verification.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Initially, only votes can be delegated.
 
 > **NOTE** THIS IS IN DEVELOPMENT, NOT READY FOR USE IN PRODUCTION
 
-## Usage
-
-ActionDelegator does not provides new Components or Participatory Spaces but enhances some functionalities in them.
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -34,6 +30,20 @@ bundle
 bundle exec rails decidim_action_delegator:install:migrations
 bundle exec rails db:migrate
 ```
+
+## Usage
+
+ActionDelegator does not provides new Components or Participatory Spaces but enhances some functionalities in them.
+
+### Extended consultation results
+
+This gem modifies the consultation's results page adding two extra columns `Membership type` and `Membership weight`. This requires a Decidim verification that creates `decidim_authorizations` records which include the following JSON structure in the `metadata` column:
+
+```json
+"{ metadata_type: '',   metadata_weight: '' }"
+```
+
+See https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/2 as an example of such verification.
 
 ## Contributing
 

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -7,7 +7,7 @@ module Decidim
     # This query completely relies on the schema of the `metadata` of the relevant
     # `decidim_authorizations` records, which is expected to be like:
     #
-    #   '{ metadata_type: "a type",   metadata_weight: "a number" }'
+    #   "{ metadata_type: '',   metadata_weight: '' }"
     #
     # Note that although we assume `metadata_type` to be a string and `metadata_weight` to be an
     # integer, there are no implications in the code for their actual data type.

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -2,6 +2,15 @@
 
 module Decidim
   module ActionDelegator
+    # Returns total votes of each response by memberships' type and weight.
+    #
+    # This query completely relies on the schema of the `metadata` of the relevant
+    # `decidim_authorizations` records, which is expected to be like:
+    #
+    #   '{ metadata_type: "a type",   metadata_weight: "a number" }'
+    #
+    # Note that although we assume `metadata_type` to be a string and `metadata_weight` to be an
+    # integer, there are no implications in the code for their actual data type.
     class ResponsesByMembership < Rectify::Query
       def initialize(question)
         @question = question
@@ -37,6 +46,8 @@ module Decidim
         SQL
       end
 
+      # Retuns the value of the specified key in the `metadata` JSONB PostgreSQL column. More
+      # details: https://www.postgresql.org/docs/current/functions-json.html
       def metadata_field(name)
         "decidim_authorizations.metadata ->> '#{name}'"
       end

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module ActionDelegator
-    class ResponsesByMembershipType < Rectify::Query
+    class ResponsesByMembership < Rectify::Query
       def initialize(question)
         @question = question
       end

--- a/app/queries/decidim/action_delegator/responses_by_membership_type.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership_type.rb
@@ -11,11 +11,17 @@ module Decidim
         question
           .responses
           .joins(:votes)
-          .joins("INNER JOIN decidim_authorizations ON decidim_authorizations.decidim_user_id = decidim_consultations_votes.decidim_author_id")
-          .group(:title, "decidim_authorizations.metadata ->> 'membership_type'")
+          .joins("INNER JOIN decidim_authorizations
+                  ON decidim_authorizations.decidim_user_id = decidim_consultations_votes.decidim_author_id")
+          .group(
+            :title,
+            "decidim_authorizations.metadata ->> 'membership_type'",
+            "decidim_authorizations.metadata ->> 'membership_weight'"
+          )
           .select(
             :title,
             "decidim_authorizations.metadata ->> 'membership_type' AS membership_type",
+            "decidim_authorizations.metadata ->> 'membership_weight' AS membership_weight",
             "COUNT(*) AS votes_count"
           )
           .order("votes_count DESC")

--- a/app/queries/decidim/action_delegator/responses_by_membership_type.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership_type.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class ResponsesByMembershipType < Rectify::Query
+      def initialize(question)
+        @question = question
+      end
+
+      def query
+        question
+          .responses
+          .joins(:votes)
+          .joins("INNER JOIN decidim_authorizations ON decidim_authorizations.decidim_user_id = decidim_consultations_votes.decidim_author_id")
+          .group(:title, "decidim_authorizations.metadata ->> 'membership_type'")
+          .select(
+            :title,
+            "decidim_authorizations.metadata ->> 'membership_type' AS membership_type",
+            "COUNT(*) AS votes_count"
+          )
+          .order("votes_count DESC")
+      end
+
+      private
+
+      attr_reader :question
+    end
+  end
+end

--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -1,0 +1,44 @@
+<div class="card" id="consultations">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t "decidim.admin.titles.results" %>
+      <span class="label button--title">
+        <%= t "decidim.admin.consultations.results.total_votes", count: current_consultation.total_votes %>
+        /
+        <%= t "decidim.admin.consultations.results.participants", count: current_consultation.total_participants %>
+      </span>
+    </h2>
+  </div>
+  <div class="card-section">
+    <table class="table-list">
+      <% current_consultation.questions.published.includes(:responses).each do |question| %>
+        <% unless question.external_voting %>
+          <thead>
+            <tr>
+              <th><%= strip_tags translated_attribute question.title %></th>
+              <th><%= I18n.t("decidim.admin.consultations.results.membership_type") %></th>
+              <th class="table-list__actions">
+                <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
+                /
+                <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if question.publishable_results? %>
+              <% Decidim::ActionDelegator::ResponsesByMembershipType.new(question).query.each do |group| %>
+              <tr>
+                <td><%= strip_tags translated_attribute group.title %></td>
+                <td class="membership-type"><%= group.membership_type %></td>
+                <td class="votes-count"><%= group.votes_count %></td>
+              </tr>
+              <% end %>
+            <% else %>
+              <tr><td><em><%= t "decidim.admin.consultations.results.not_visible" %></em></td><td>&nbsp;</td></tr>
+            <% end %>
+          </tbody>
+        <% end %>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -27,7 +27,7 @@
           </thead>
           <tbody>
             <% if question.publishable_results? %>
-              <% Decidim::ActionDelegator::ResponsesByMembershipType.new(question).query.each do |group| %>
+              <% Decidim::ActionDelegator::ResponsesByMembership.new(question).query.each do |group| %>
               <tr>
                 <td><%= strip_tags translated_attribute group.title %></td>
                 <td class="membership-type"><%= group.membership_type %></td>

--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -17,6 +17,7 @@
             <tr>
               <th><%= strip_tags translated_attribute question.title %></th>
               <th><%= I18n.t("decidim.admin.consultations.results.membership_type") %></th>
+              <th><%= I18n.t("decidim.admin.consultations.results.membership_weight") %></th>
               <th class="table-list__actions">
                 <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
                 /
@@ -30,6 +31,7 @@
               <tr>
                 <td><%= strip_tags translated_attribute group.title %></td>
                 <td class="membership-type"><%= group.membership_type %></td>
+                <td class="membership-weight"><%= group.membership_weight %></td>
                 <td class="votes-count"><%= group.votes_count %></td>
               </tr>
               <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
       consultations:
         results:
           membership_type: Membership type
+          membership_weight: Weight
   layouts:
     decidim:
       user_profile:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,10 @@ en:
       delegations_verifier:
         explanation: Verified users with this method can delegate votes to other users
         name: Delegations Verifier
+    admin:
+      consultations:
+        results:
+          membership_type: Membership type
   layouts:
     decidim:
       user_profile:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,11 @@ en:
           members:
             index:
               title: Members management
+    admin:
+      consultations:
+        results:
+          membership_type: Membership type
+          membership_weight: Weight
     authorization_handlers:
       admin:
         delegations_verifier:
@@ -76,11 +81,6 @@ en:
       delegations_verifier:
         explanation: Verified users with this method can delegate votes to other users
         name: Delegations Verifier
-    admin:
-      consultations:
-        results:
-          membership_type: Membership type
-          membership_weight: Weight
   layouts:
     decidim:
       user_profile:

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -22,6 +22,8 @@ module Decidim::ActionDelegator
         "/app/views/decidim/consultations/questions/_vote_button.html.erb" => "036bbb6a3e37062ed37325da8d48ed36",
         "/app/views/decidim/consultations/questions/_vote_modal.html.erb" => "b23948e4ed7e0360a09faef326bc3664",
         "/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb" => "7eb753c457e9a5adc6c16efd155ba434",
+        "/app/views/decidim/consultations/admin/consultations/results.html.erb" => "1a2f7afd79b20b1fcf66bdece660e8ae",
+
         # monkeypatches
         "/app/commands/decidim/consultations/vote_question.rb" => "8d89031039a1ba2972437d13687a72b5",
         "/app/controllers/decidim/consultations/question_votes_controller.rb" => "69bf764e99dfcdae138613adbed28b84",

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::ResponsesByMembership do
+  subject { described_class.new(question) }
+
+  let(:organization) { create(:organization) }
+  let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+  let(:question) { create(:question, consultation: consultation) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:response) { create(:response, question: question) }
+
+  before do
+    question.votes.create(author: user, response: response)
+    question.votes.create(author: other_user, response: response)
+
+    create(:authorization, user: user, metadata: auth_metadata)
+    create(:authorization, user: other_user, metadata: other_auth_metadata)
+  end
+
+  describe "#query" do
+    context "when users have the same membership_weight" do
+      let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+      let(:other_auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+
+      it "returns response votes by membership's type and weight in a single row" do
+        result = subject.query
+
+        expect(result.first.membership_type).to eq("producer")
+        expect(result.first.membership_weight).to eq("2")
+        expect(result.first.votes_count).to eq(2)
+      end
+    end
+
+    context "when users have different membership_weight" do
+      let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+      let(:other_auth_metadata) { { membership_type: "producer", membership_weight: 1 } }
+
+      it "returns response votes by membership's type in different rows" do
+        result = subject.query
+
+        expect(result.first.membership_type).to eq("producer")
+        expect(result.first.membership_weight).to eq("1")
+        expect(result.first.votes_count).to eq(1)
+
+        expect(result.second.membership_type).to eq("producer")
+        expect(result.second.membership_weight).to eq("2")
+        expect(result.second.votes_count).to eq(1)
+      end
+    end
+
+    context "when users have different membership_type" do
+      let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+      let(:other_auth_metadata) { { membership_type: "consumer", membership_weight: 2 } }
+
+      it "returns response votes by membership's type in different rows" do
+        result = subject.query
+
+        expect(result.first.membership_type).to eq("consumer")
+        expect(result.first.membership_weight).to eq("2")
+        expect(result.first.votes_count).to eq(1)
+
+        expect(result.second.membership_type).to eq("producer")
+        expect(result.second.membership_weight).to eq("2")
+        expect(result.second.votes_count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -24,8 +24,12 @@ describe "Admin manages consultation results", type: :system do
     let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
     let!(:other_vote) { question.votes.create(author: other_user, response: response) }
 
-    let!(:authorization) { create(:authorization, user: user, metadata: { membership_type: "producer" }) }
-    let!(:other_authorization) { create(:authorization, user: other_user, metadata: { membership_type: "consumer" }) }
+    let!(:authorization) do
+      create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
+    end
+    let!(:other_authorization) do
+      create(:authorization, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
+    end
 
     let(:votes) { consultation.questions.first.total_votes }
 
@@ -35,17 +39,20 @@ describe "Admin manages consultation results", type: :system do
       expect(page).to have_content(/#{translated(consultation.questions.first.responses.first.title)}/i)
     end
 
-    it "shows votes by membership type" do
+    it "shows votes by membership and weight type" do
       visit decidim_admin_consultations.results_consultation_path(consultation)
 
       expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_type").upcase)
+      expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_weight").upcase)
 
       first_row = find(:xpath, ".//table/tbody/tr[1]")
       expect(first_row.find(".membership-type")).to have_content("consumer")
+      expect(first_row.find(".membership-weight")).to have_content(3)
       expect(first_row.find(".votes-count")).to have_content(1)
 
       second_row = find(:xpath, ".//table/tbody/tr[2]")
       expect(second_row.find(".membership-type")).to have_content("producer")
+      expect(second_row.find(".membership-weight")).to have_content(2)
       expect(second_row.find(".votes-count")).to have_content(1)
     end
   end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages consultation results", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let(:total_votes) { I18n.t("decidim.admin.consultations.results.total_votes", count: votes) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_consultations.results_consultation_path(consultation)
+  end
+
+  context "when viewing a finished consultation with votes" do
+    let!(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+    let!(:question) { create(:question, consultation: consultation) }
+    let!(:response) { create(:response, question: question) }
+
+    let!(:vote) { question.votes.create(author: user, response: response) }
+
+    let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:other_vote) { question.votes.create(author: other_user, response: response) }
+
+    let!(:authorization) { create(:authorization, user: user, metadata: { membership_type: "producer" }) }
+    let!(:other_authorization) { create(:authorization, user: other_user, metadata: { membership_type: "consumer" }) }
+
+    let(:votes) { consultation.questions.first.total_votes }
+
+    it "shows votes total" do
+      visit decidim_admin_consultations.results_consultation_path(consultation)
+      expect(page).to have_content(/#{total_votes}/i)
+      expect(page).to have_content(/#{translated(consultation.questions.first.responses.first.title)}/i)
+    end
+
+    it "shows votes by membership type" do
+      visit decidim_admin_consultations.results_consultation_path(consultation)
+
+      expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_type").upcase)
+
+      first_row = find(:xpath, ".//table/tbody/tr[1]")
+      expect(first_row.find(".membership-type")).to have_content("consumer")
+      expect(first_row.find(".votes-count")).to have_content(1)
+
+      second_row = find(:xpath, ".//table/tbody/tr[2]")
+      expect(second_row.find(".membership-type")).to have_content("producer")
+      expect(second_row.find(".votes-count")).to have_content(1)
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

This closes https://github.com/coopdevs/decidim-coopcat/issues/2. 

This modifies the consultation's result page to display the metadata included in users' authorizations. This relies on the following particular format. Things will be slightly off if the metadata doesn't stick to it (there's no enforce schema).

```json
"{ metadata_type: '',   metadata_weight: '' }"
```

## :camera_flash: 

![Screenshot from 2020-09-29 14-58-09](https://user-images.githubusercontent.com/762088/94561395-35f27780-0264-11eb-9398-22193cd3c8ce.png)
