### PR TITLE
Notify pushes to master to decidim-coopcat

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,19 @@
+name: Notify change
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/coopdevs/decidim-coopcat/actions/workflows/main.yml/dispatches \
+            -u "sauloperez:${{secrets.GH_API_TOKEN}}" \
+            -d '{"ref":"master"}'


### PR DESCRIPTION
This triggers a `workflow_dispatch` event in decidim-coopcat, which in turn will update decidim-coopcat's Gemfile.lock and deploy. See https://github.com/coopdevs/decidim-coopcat/pull/31 for reference.