### PR TITLE
Fetch the appropriate secret token

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,5 +15,5 @@ jobs:
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/coopdevs/decidim-coopcat/actions/workflows/main.yml/dispatches \
-            -u "sauloperez:${{secrets.GH_API_TOKEN}}" \
+            -u "sauloperez:${{secrets.COOPCAT_GH_API_TOKEN}}" \
             -d '{"ref":"master"}'


### PR DESCRIPTION
I added the secret in decidim-coopcat and not this repo and so the POST request wasn't authorized.