### PR TITLE
Display border in all table columns

### DIFF
--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -36,7 +36,12 @@
               </tr>
               <% end %>
             <% else %>
-              <tr><td><em><%= t "decidim.admin.consultations.results.not_visible" %></em></td><td>&nbsp;</td></tr>
+              <tr>
+                <td><em><%= t "decidim.admin.consultations.results.not_visible" %></em></td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+              </tr>
             <% end %>
           </tbody>
         <% end %>


### PR DESCRIPTION
The number of columns when the consultation is not yet finished didn't match the number of columns when it is.

### Before

![Screenshot from 2020-09-30 09-02-02](https://user-images.githubusercontent.com/762088/94653533-042cef80-02fc-11eb-9a39-76cf43826ae5.png)


### After

![Screenshot from 2020-09-30 09-02-16](https://user-images.githubusercontent.com/762088/94653541-08590d00-02fc-11eb-9158-b77ed8ca0ede.png)
