### PR TITLE
Order results table by its columns

### DIFF
--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -32,7 +32,7 @@ module Decidim
             metadata_field_with_alias("membership_weight"),
             "COUNT(*) AS votes_count"
           )
-          .order("votes_count DESC")
+          .order("title ASC, membership_type ASC, membership_weight DESC, votes_count DESC")
       end
 
       private

--- a/app/views/decidim/consultations/admin/consultations/results.html.erb
+++ b/app/views/decidim/consultations/admin/consultations/results.html.erb
@@ -29,7 +29,7 @@
             <% if question.publishable_results? %>
               <% Decidim::ActionDelegator::ResponsesByMembership.new(question).query.each do |group| %>
               <tr>
-                <td><%= strip_tags translated_attribute group.title %></td>
+                <td class="response-title"><%= strip_tags translated_attribute group.title %></td>
                 <td class="membership-type"><%= group.membership_type %></td>
                 <td class="membership-weight"><%= group.membership_weight %></td>
                 <td class="votes-count"><%= group.votes_count %></td>

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -42,11 +42,11 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
         result = subject.query
 
         expect(result.first.membership_type).to eq("producer")
-        expect(result.first.membership_weight).to eq("1")
+        expect(result.first.membership_weight).to eq("2")
         expect(result.first.votes_count).to eq(1)
 
         expect(result.second.membership_type).to eq("producer")
-        expect(result.second.membership_weight).to eq("2")
+        expect(result.second.membership_weight).to eq("1")
         expect(result.second.votes_count).to eq(1)
       end
     end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -17,18 +17,38 @@ describe "Admin manages consultation results", type: :system do
   context "when viewing a finished consultation with votes" do
     let!(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
     let!(:question) { create(:question, consultation: consultation) }
-    let!(:response) { create(:response, question: question) }
+    let!(:response) do
+      create(
+        :response,
+        question: question,
+        title: { "en" => "A", "ca" => "A", "es" => "A" }
+      )
+    end
 
     let!(:vote) { question.votes.create(author: user, response: response) }
 
     let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
     let!(:other_vote) { question.votes.create(author: other_user, response: response) }
 
-    let!(:authorization) do
-      create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
+    let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:another_vote) { question.votes.create(author: another_user, response: response) }
+
+    let!(:other_response) do
+      create(
+        :response,
+        question: question,
+        title: { "en" => "B", "ca" => "B", "es" => "B" }
+      )
     end
-    let!(:other_authorization) do
+    let!(:yet_another_user) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:yet_another_vote) { question.votes.create(author: yet_another_user, response: other_response) }
+
+    before do
+      create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
       create(:authorization, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
+      create(:authorization, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+
+      create(:authorization, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
     end
 
     let(:votes) { consultation.questions.first.total_votes }
@@ -45,15 +65,29 @@ describe "Admin manages consultation results", type: :system do
       expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_type").upcase)
       expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_weight").upcase)
 
-      first_row = find(:xpath, ".//table/tbody/tr[1]")
-      expect(first_row.find(".membership-type")).to have_content("consumer")
-      expect(first_row.find(".membership-weight")).to have_content(3)
-      expect(first_row.find(".votes-count")).to have_content(1)
+      expect(nth_row(1).find(".response-title")).to have_content("A")
+      expect(nth_row(1).find(".membership-type")).to have_content("consumer")
+      expect(nth_row(1).find(".membership-weight")).to have_content(3)
+      expect(nth_row(1).find(".votes-count")).to have_content(1)
 
-      second_row = find(:xpath, ".//table/tbody/tr[2]")
-      expect(second_row.find(".membership-type")).to have_content("producer")
-      expect(second_row.find(".membership-weight")).to have_content(2)
-      expect(second_row.find(".votes-count")).to have_content(1)
+      expect(nth_row(2).find(".response-title")).to have_content("A")
+      expect(nth_row(2).find(".membership-type")).to have_content("consumer")
+      expect(nth_row(2).find(".membership-weight")).to have_content(1)
+      expect(nth_row(2).find(".votes-count")).to have_content(1)
+
+      expect(nth_row(3).find(".response-title")).to have_content("A")
+      expect(nth_row(3).find(".membership-type")).to have_content("producer")
+      expect(nth_row(3).find(".membership-weight")).to have_content(2)
+      expect(nth_row(3).find(".votes-count")).to have_content(1)
+
+      expect(nth_row(4).find(".response-title")).to have_content("B")
+      expect(nth_row(4).find(".membership-type")).to have_content("consumer")
+      expect(nth_row(4).find(".membership-weight")).to have_content(1)
+      expect(nth_row(4).find(".votes-count")).to have_content(1)
+    end
+
+    def nth_row(number)
+      find(:xpath, ".//table/tbody/tr[#{number}]")
     end
   end
 end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -24,15 +24,6 @@ describe "Admin manages consultation results", type: :system do
         title: { "en" => "A", "ca" => "A", "es" => "A" }
       )
     end
-
-    let!(:vote) { question.votes.create(author: user, response: response) }
-
-    let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:other_vote) { question.votes.create(author: other_user, response: response) }
-
-    let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:another_vote) { question.votes.create(author: another_user, response: response) }
-
     let!(:other_response) do
       create(
         :response,
@@ -40,18 +31,25 @@ describe "Admin manages consultation results", type: :system do
         title: { "en" => "B", "ca" => "B", "es" => "B" }
       )
     end
+
+    let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }
     let!(:yet_another_user) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:yet_another_vote) { question.votes.create(author: yet_another_user, response: other_response) }
+
+    let(:votes) { consultation.questions.first.total_votes }
 
     before do
+      question.votes.create(author: user, response: response)
+      question.votes.create(author: other_user, response: response)
+      question.votes.create(author: another_user, response: response)
+      question.votes.create(author: yet_another_user, response: other_response)
+
       create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
       create(:authorization, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
       create(:authorization, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
 
       create(:authorization, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
     end
-
-    let(:votes) { consultation.questions.first.total_votes }
 
     it "shows votes total" do
       visit decidim_admin_consultations.results_consultation_path(consultation)


### PR DESCRIPTION
It sorts them from left to right. That is, the same responses together, then the membership types together, etc.

![Screenshot from 2020-09-30 17-10-38](https://user-images.githubusercontent.com/762088/94704324-13ce2780-0340-11eb-9b8a-c991e57e835e.png)
