### PR TITLE
Remove useless expires_at column

### DIFF
--- a/app/controllers/decidim/action_delegator/admin/settings_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/settings_controller.rb
@@ -51,7 +51,7 @@ module Decidim
         private
 
         def setting_params
-          params.require(:setting).permit(:max_grants, :expires_at, :decidim_consultation_id)
+          params.require(:setting).permit(:max_grants, :decidim_consultation_id)
         end
 
         def build_setting

--- a/app/models/decidim/action_delegator/setting.rb
+++ b/app/models/decidim/action_delegator/setting.rb
@@ -15,16 +15,8 @@ module Decidim
                foreign_key: "decidim_action_delegator_setting_id",
                dependent: :destroy
 
-      validate :expires_at_in_the_future
-
-      validates :max_grants, :expires_at, presence: true
+      validates :max_grants, presence: true
       validates :max_grants, numericality: { greater_than: 0 }
-
-      private
-
-      def expires_at_in_the_future
-        errors.add(:expires_at, "can't be in the past") if expires_at.present? && expires_at < Time.current
-      end
     end
   end
 end

--- a/app/views/decidim/action_delegator/admin/settings/new.html.erb
+++ b/app/views/decidim/action_delegator/admin/settings/new.html.erb
@@ -21,10 +21,6 @@
       <div class="row column">
         <%= f.number_field :max_grants, min: 1, autofocus: true %>
       </div>
-
-      <div class="row column">
-        <%= f.date_field :expires_at, min: Date.today %>
-      </div>
     </div>
   </div>
 

--- a/db/migrate/20201001172345_remove_expires_at_from_delegations.rb
+++ b/db/migrate/20201001172345_remove_expires_at_from_delegations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveExpiresAtFromDelegations < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :decidim_action_delegator_settings, :expires_at
+  end
+end

--- a/lib/decidim/action_delegator/test/factories.rb
+++ b/lib/decidim/action_delegator/test/factories.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
 
   factory :setting, class: "Decidim::ActionDelegator::Setting" do
     max_grants { 3 }
-    expires_at { Time.zone.now + 2.days }
     consultation
   end
 end

--- a/spec/controllers/decidim/action_delegator/admin/settings_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/settings_controller_spec.rb
@@ -48,7 +48,7 @@ module Decidim
 
       describe "#create" do
         let(:setting_params) do
-          { setting: { max_grants: 2, expires_at: 2.days.from_now.to_date, decidim_consultation_id: consultation.id } }
+          { setting: { max_grants: 2, decidim_consultation_id: consultation.id } }
         end
 
         it "authorizes the action" do

--- a/spec/models/decidim/action_delegator/settings_spec.rb
+++ b/spec/models/decidim/action_delegator/settings_spec.rb
@@ -11,18 +11,7 @@ module Decidim
       it { is_expected.to have_many(:delegations).dependent(:destroy) }
 
       it { is_expected.to validate_presence_of(:max_grants) }
-      it { is_expected.to validate_presence_of(:expires_at) }
       it { is_expected.to validate_numericality_of(:max_grants).is_greater_than(0) }
-
-      context "when the expires_at is in the past" do
-        subject { build(:setting, expires_at: Time.zone.now - 1.day) }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context "when the expires_at is in the future" do
-        it { is_expected.to be_valid }
-      end
     end
   end
 end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_settings_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_settings_spec.rb
@@ -23,7 +23,6 @@ describe "Admin manages settings", type: :system do
     it "creates a new setting" do
       within ".new_setting" do
         fill_in :setting_max_grants, with: 5
-        fill_in :setting_expires_at, with: 2.days.from_now.to_date
         select consultation_translated_title, from: :setting_decidim_consultation_id
 
         find("*[type=submit]").click


### PR DESCRIPTION
Since a setting is tied to a consultation, all its delegations will become stale when the consultation is over removing the need for
an `expires_at`. They'll need to create a new Setting and new Delegation records.

## :camera_flash: 

![Screenshot from 2020-10-01 19-39-42](https://user-images.githubusercontent.com/762088/94844027-e2c42480-041d-11eb-9bc7-f3e73876acc2.png)
