### PR TITLE
SMS Verification via SomConnexió gateway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "decidim-consultations", Decidim::ActionDelegator::DECIDIM_VERSION
 
 gem "bootsnap", "~> 1.4"
 gem "puma", ">= 4.3"
+gem "savon", "~> 2.12"
 gem "uglifier", "~> 4.1"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       decidim-admin (= 0.21.0)
       decidim-consultations (= 0.21.0)
       decidim-core (= 0.21.0)
+      savon
 
 GEM
   remote: https://rubygems.org/
@@ -57,6 +58,9 @@ GEM
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
     anchored (1.1.0)
     arel (9.0.0)
     ast (2.4.1)
@@ -405,6 +409,8 @@ GEM
       railties
       sprockets-rails
     graphql (1.11.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
@@ -416,6 +422,9 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    httpi (2.4.5)
+      rack
+      socksify
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.31)
@@ -500,6 +509,7 @@ GEM
     nobspw (0.6.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nori (2.6.0)
     oauth (0.5.4)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -674,6 +684,14 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
+    savon (2.12.1)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.8.1)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
     searchlight (4.1.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -690,6 +708,7 @@ GEM
     smart_properties (1.15.0)
     social-share-button (1.2.3)
       coffee-rails
+    socksify (1.7.1)
     spreadsheet (1.2.6)
       ruby-ole (>= 1.0)
     spring (2.1.0)
@@ -738,6 +757,10 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.8)
       rack (>= 2.0.6)
+    wasabi (3.6.1)
+      addressable
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -770,6 +793,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (>= 4.3)
+  savon (~> 2.12)
   shoulda-matchers
   simplecov-cobertura
   spring (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ structure in the `metadata` column:
 See https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/2
 as an example of such verification.
 
+### SMS gateway setup
+
+In order to use this new sms gateway you need to configure your application. In config/initializers/decidim.rb set:
+
+```ruby
+config.sms_gateway_service = 'Decidim::ActionDelegator::SmsGateway'
+```
+
+Then you'll need to set the following ENV vars:
+
+```bash
+SMS_USER=
+SMS_PASS=
+SMS_SENDER_NAME= (optional)
+```
+
+This gateway uses Som Connexió as a provider which uses [this SOAP API](https://websms.masmovil.com/api_php/smsvirtual.wsdl).
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).

--- a/app/jobs/decidim/action_delegator/send_sms_job.rb
+++ b/app/jobs/decidim/action_delegator/send_sms_job.rb
@@ -8,7 +8,7 @@ module Decidim
     class SendSmsJob < ApplicationJob
       queue_as :default
 
-      SMSVIRTUAL_WSDL_URL = "https://websms.masmovil.com/api_php/smsvirtual.wsdl".freeze
+      SMSVIRTUAL_WSDL_URL = "https://websms.masmovil.com/api_php/smsvirtual.wsdl"
 
       def perform(sender_name, mobile_phone_number, message)
         @sender_name = sender_name

--- a/app/jobs/decidim/action_delegator/send_sms_job.rb
+++ b/app/jobs/decidim/action_delegator/send_sms_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "savon"
+
+module Decidim
+  module ActionDelegator
+    class SendSmsJob < ApplicationJob
+      queue_as :default
+
+      def perform(mobile_phone_number)
+        client = ::Savon.client(wsdl: "https://websms.smsvirtual.es/api_php/smsvirtual.wsdl")
+
+        response = client.call(:send_sms,
+                               message: {
+                                 user: ENV["SMS_USER"],
+                                 pass: ENV["SMS_PASS"],
+                                 src: "Coopcat",
+                                 dst: mobile_phone_number,
+                                 msg: "Test"
+                               })
+
+        Rails.logger.debug response
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/action_delegator/send_sms_job.rb
+++ b/app/jobs/decidim/action_delegator/send_sms_job.rb
@@ -4,22 +4,58 @@ require "savon"
 
 module Decidim
   module ActionDelegator
+    class SendSmsJobException < StandardError; end
     class SendSmsJob < ApplicationJob
       queue_as :default
 
-      def perform(mobile_phone_number)
-        client = ::Savon.client(wsdl: "https://websms.masmovil.com/api_php/smsvirtual.wsdl")
+      attr_reader :response
 
-        response = client.call(:send_sms,
-                               message: {
-                                 user: ENV["SMS_USER"],
-                                 pass: ENV["SMS_PASS"],
-                                 src: "Coopcat",
-                                 dst: mobile_phone_number,
-                                 msg: "Test"
-                               })
+      SMSVIRTUAL_WSDL_URL = "https://websms.masmovil.com/api_php/smsvirtual.wsdl"
 
-        Rails.logger.debug response
+      def perform(sender_name, mobile_phone_number, message)
+        @sender_name = sender_name
+        @mobile_phone_number = mobile_phone_number
+        @message = message
+
+        send_sms!
+
+        raise SendSmsJobException, @response unless success?
+      end
+
+      private
+
+      attr_reader :sender_name, :mobile_phone_number, :message
+
+      def send_sms!
+        @response = client.call(:send_sms,
+                                message: {
+                                  user: ENV["SMS_USER"],
+                                  pass: ENV["SMS_PASS"],
+                                  src: sender_name,
+                                  dst: mobile_phone_number,
+                                  msg: message
+                                })
+      end
+
+      def success?
+        parsed_response[:code] == "200"
+      end
+
+      def client
+        @client ||= ::Savon.client(wsdl: SMSVIRTUAL_WSDL_URL)
+      end
+
+      def parsed_response
+        return @parsed_response if @parsed_response
+
+        doc = Nokogiri::XML response.body[:send_sms_response][:result]
+
+        @parsed_response = {
+          code: doc.xpath("//codigo").text,
+          description: doc.xpath("//descripcion").text
+        }
+
+        @parsed_response
       end
     end
   end

--- a/app/jobs/decidim/action_delegator/send_sms_job.rb
+++ b/app/jobs/decidim/action_delegator/send_sms_job.rb
@@ -8,9 +8,7 @@ module Decidim
     class SendSmsJob < ApplicationJob
       queue_as :default
 
-      attr_reader :response
-
-      SMSVIRTUAL_WSDL_URL = "https://websms.masmovil.com/api_php/smsvirtual.wsdl"
+      SMSVIRTUAL_WSDL_URL = "https://websms.masmovil.com/api_php/smsvirtual.wsdl".freeze
 
       def perform(sender_name, mobile_phone_number, message)
         @sender_name = sender_name
@@ -19,12 +17,12 @@ module Decidim
 
         send_sms!
 
-        raise SendSmsJobException, @response unless success?
+        raise SendSmsJobException, response unless success?
       end
 
       private
 
-      attr_reader :sender_name, :mobile_phone_number, :message
+      attr_reader :sender_name, :mobile_phone_number, :message, :response
 
       def send_sms!
         @response = client.call(:send_sms,

--- a/app/jobs/decidim/action_delegator/send_sms_job.rb
+++ b/app/jobs/decidim/action_delegator/send_sms_job.rb
@@ -8,7 +8,7 @@ module Decidim
       queue_as :default
 
       def perform(mobile_phone_number)
-        client = ::Savon.client(wsdl: "https://websms.smsvirtual.es/api_php/smsvirtual.wsdl")
+        client = ::Savon.client(wsdl: "https://websms.masmovil.com/api_php/smsvirtual.wsdl")
 
         response = client.call(:send_sms,
                                message: {

--- a/app/overrides/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/app/overrides/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Decidim::Verifications::Sms::AuthorizationsController.class_eval do
+  def new
+    enforce_permission_to :create, :authorization, authorization: authorization
+
+    flash.now[:error] = I18n.t("decidim.action_delegator.authorizations.new.missing_phone_error") unless direct_authorization && membership_phone
+
+    @form = Decidim::Verifications::Sms::MobilePhoneForm.new mobile_phone_number: membership_phone
+  end
+
+  private
+
+  def direct_authorization
+    @direct_authorization ||= Decidim::Authorization.find_by(
+      user: current_user,
+      name: "direct_verifications"
+    )
+  end
+
+  def membership_phone
+    return nil unless direct_authorization
+
+    direct_authorization.metadata["membership_phone"]
+  end
+end

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -19,7 +19,7 @@ module Decidim
       private
 
       def sender_name
-        ENV["SMS_SENDER_NAME"] || "Decidim"
+        ENV["SMS_SENDER_NAME"] || Decidim.application_name
       end
 
       def message

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class SmsGateway
+      attr_reader :mobile_phone_number, :code, :response
+
+      def initialize(mobile_phone_number, code)
+        @mobile_phone_number = mobile_phone_number
+        @code = code
+      end
+
+      def deliver_code
+        send_sms!
+
+        success?
+      end
+
+      def success?
+        parsed_response[:code] == "200"
+      end
+
+      private
+
+      def parsed_response
+        return @parsed_response if @parsed_response
+
+        doc = Nokogiri::XML response.body[:send_sms_response][:result]
+
+        @parsed_response = {
+          code: doc.xpath("//codigo").text,
+          description: doc.xpath("//description").text
+        }
+
+        @parsed_response
+      end
+
+      def send_sms!
+        @response = client.call(:send_sms,
+                                message: {
+                                  user: ENV["SMS_USER"],
+                                  pass: ENV["SMS_PASS"],
+                                  src: sender_name,
+                                  dst: mobile_phone_number,
+                                  msg: message
+                                })
+
+        Rails.logger.debug "==========="
+        Rails.logger.debug ["action_delegator_gateway", "send_sms!", response].map(&:inspect).join("\n")
+        Rails.logger.debug "==========="
+      end
+
+      def sender_name
+        ENV["SMS_SENDER_NAME"] || "Decidim"
+      end
+
+      def client
+        @client ||= ::Savon.client(wsdl: "https://websms.smsvirtual.es/api_php/smsvirtual.wsdl")
+      end
+
+      def message
+        I18n.t("decidim.action_delegator.sms_message", code: code)
+      end
+    end
+  end
+end

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -29,7 +29,7 @@ module Decidim
 
         @parsed_response = {
           code: doc.xpath("//codigo").text,
-          description: doc.xpath("//description").text
+          description: doc.xpath("//descripcion").text
         }
 
         @parsed_response

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -55,7 +55,7 @@ module Decidim
       end
 
       def client
-        @client ||= ::Savon.client(wsdl: "https://websms.smsvirtual.es/api_php/smsvirtual.wsdl")
+        @client ||= ::Savon.client(wsdl: "https://websms.masmovil.com/api_php/smsvirtual.wsdl")
       end
 
       def message

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -16,11 +16,11 @@ module Decidim
         success?
       end
 
+      private
+
       def success?
         parsed_response[:code] == "200"
       end
-
-      private
 
       def parsed_response
         return @parsed_response if @parsed_response

--- a/app/services/decidim/action_delegator/sms_gateway.rb
+++ b/app/services/decidim/action_delegator/sms_gateway.rb
@@ -11,51 +11,15 @@ module Decidim
       end
 
       def deliver_code
-        send_sms!
+        SendSmsJob.perform_later(sender_name, mobile_phone_number, message)
 
-        success?
+        true
       end
 
       private
 
-      def success?
-        parsed_response[:code] == "200"
-      end
-
-      def parsed_response
-        return @parsed_response if @parsed_response
-
-        doc = Nokogiri::XML response.body[:send_sms_response][:result]
-
-        @parsed_response = {
-          code: doc.xpath("//codigo").text,
-          description: doc.xpath("//descripcion").text
-        }
-
-        @parsed_response
-      end
-
-      def send_sms!
-        @response = client.call(:send_sms,
-                                message: {
-                                  user: ENV["SMS_USER"],
-                                  pass: ENV["SMS_PASS"],
-                                  src: sender_name,
-                                  dst: mobile_phone_number,
-                                  msg: message
-                                })
-
-        Rails.logger.debug "==========="
-        Rails.logger.debug ["action_delegator_gateway", "send_sms!", response].map(&:inspect).join("\n")
-        Rails.logger.debug "==========="
-      end
-
       def sender_name
         ENV["SMS_SENDER_NAME"] || "Decidim"
-      end
-
-      def client
-        @client ||= ::Savon.client(wsdl: "https://websms.masmovil.com/api_php/smsvirtual.wsdl")
       end
 
       def message

--- a/app/views/decidim/verifications/sms/authorizations/new.html.erb
+++ b/app/views/decidim/verifications/sms/authorizations/new.html.erb
@@ -1,0 +1,31 @@
+<div class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center page-title">
+        <h1><%= t(".title") %></h1>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns large-6 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <%= decidim_form_for(@form, url: authorization_path(redirect_url: redirect_url)) do |form| %>
+              <div class="field">
+                <%= form.text_field :mobile_phone_number, readonly: true %>
+              </div>
+
+              <div class="callout announcement mb-sm warning cell-announcement">
+                <p><%= t('decidim.action_delegator.authorizations.new.phone_warning') %></p>
+              </div>
+
+              <div class="actions">
+                <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}...", disabled: @form.mobile_phone_number.blank? %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/verifications/sms/authorizations/new.html.erb
+++ b/app/views/decidim/verifications/sms/authorizations/new.html.erb
@@ -16,7 +16,7 @@
               </div>
 
               <div class="callout announcement mb-sm warning cell-announcement">
-                <p><%= t('decidim.action_delegator.authorizations.new.phone_warning') %></p>
+                <p><%= t("decidim.action_delegator.authorizations.new.phone_warning") %></p>
               </div>
 
               <div class="actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,10 @@ en:
             max_grants: Maximum delegations
             save: Save
             title: Delegation settings
+      authorizations:
+        new:
+          phone_warning: This phone number has been imported by the admin. Please, reach out if it's not correct.
+          missing_phone_error: Missing membership phone
       delegations:
         link: You have delegations granted
       delegations_modal:
@@ -59,6 +63,7 @@ en:
         contextual_help: 'You have been granted the vote from:'
         title: 'Consultation: granted delegations'
       name: Decidim ActionDelegator cooperatives module
+      sms_message: "Your verification code is %{code}"
       verification:
         admin:
           members:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,9 @@ en:
             title: Delegation settings
       authorizations:
         new:
-          phone_warning: This phone number has been imported by the admin. Please, reach out if it's not correct.
           missing_phone_error: Missing membership phone
+          phone_warning: This phone number has been imported by the admin. Please,
+            reach out if it's not correct.
       delegations:
         link: You have delegations granted
       delegations_modal:
@@ -63,7 +64,7 @@ en:
         contextual_help: 'You have been granted the vote from:'
         title: 'Consultation: granted delegations'
       name: Decidim ActionDelegator cooperatives module
-      sms_message: "Your verification code is %{code}"
+      sms_message: Your verification code is %{code}
       verification:
         admin:
           members:

--- a/decidim-action_delegator.gemspec
+++ b/decidim-action_delegator.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-admin", Decidim::ActionDelegator::DECIDIM_VERSION
   s.add_dependency "decidim-consultations", Decidim::ActionDelegator::DECIDIM_VERSION
   s.add_dependency "decidim-core", Decidim::ActionDelegator::DECIDIM_VERSION
+  s.add_dependency "savon"
 
   s.add_development_dependency "decidim-dev", Decidim::ActionDelegator::DECIDIM_VERSION
 end

--- a/lib/decidim/action_delegator/engine.rb
+++ b/lib/decidim/action_delegator/engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "savon"
 require "rails"
 require "decidim/core"
 require "decidim/consultations"

--- a/spec/controllers/decidim/verifications/sms/authorizations_controller_spec.rb
+++ b/spec/controllers/decidim/verifications/sms/authorizations_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Verifications
+    module Sms
+      describe AuthorizationsController, type: :controller do
+        routes { Decidim::Verifications::Sms::Engine.routes }
+
+        let(:organization) { create :organization }
+        let(:user) { create(:user, :confirmed, organization: organization) }
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in user
+        end
+
+        describe "get #new" do
+          context "when membership_phone is missing" do
+            it "shows missing_phone_error" do
+              get :new
+              expect(response).to have_http_status(:ok)
+              expect(controller).to set_flash.now[:error].to(I18n.t("decidim.action_delegator.authorizations.new.missing_phone_error"))
+            end
+          end
+
+          context "when membership_phone is set" do
+            let!(:authorization) { create(:authorization, user: user, name: "direct_verifications", metadata: metadata) }
+            let(:metadata) { { membership_phone: membership_phone } }
+            let(:membership_phone) { "+12 345 678" }
+
+            it "does not show missing_phone_error" do
+              get :new
+              expect(response).to have_http_status(:ok)
+              expect(controller).not_to set_flash.now[:error].to(I18n.t("decidim.action_delegator.authorizations.new.missing_phone_error"))
+            end
+
+            it "initializes the MobilePhoneForm with the membership_phone" do
+              allow(Decidim::Verifications::Sms::MobilePhoneForm).to receive(:new).with(mobile_phone_number: membership_phone)
+              get :new
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
@@ -39,9 +39,7 @@ module Decidim::ActionDelegator
         let(:result) { "<xml><codigo>115</codigo><descripcion>Woopsie</descripcion></xml>" }
 
         it "returns false" do
-          expect {
-            subject.perform_now(sender_name, mobile_phone_number, message)
-          }.to raise_error(SendSmsJobException)
+          expect { subject.perform_now(sender_name, mobile_phone_number, message) }.to raise_error(SendSmsJobException)
         end
       end
     end

--- a/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ActionDelegator
+  describe SendSmsJob do
+    subject { described_class }
+
+    let(:sender_name) { "Sender" }
+    let(:mobile_phone_number) { "+12 345 6789" }
+    let(:message) { "A very important message" }
+
+    let(:client) { double("client") }
+    let(:response) { double("response") }
+    let(:response_body) { { send_sms_response: { result: result } } }
+
+    describe "queue" do
+      it "is queued to default" do
+        expect(subject.queue_name).to eq "default"
+      end
+    end
+
+    describe "#perform" do
+      before do
+        allow(Savon).to receive(:client).and_return(client)
+        allow(client).to receive(:call).and_return(response)
+        allow(response).to receive(:body).and_return(response_body)
+      end
+
+      context "when code's result is 200" do
+        let(:result) { "<xml><codigo>200</codigo><descripcion>Went well</descripcion></xml>" }
+
+        it "Does not raise SendSmsJobException" do
+          expect { subject.perform_now(sender_name, mobile_phone_number, message) }.not_to raise_error
+        end
+      end
+
+      context "when code's result isn't 200" do
+        let(:result) { "<xml><codigo>115</codigo><descripcion>Woopsie</descripcion></xml>" }
+
+        it "returns false" do
+          expect {
+            subject.perform_now(sender_name, mobile_phone_number, message)
+          }.to raise_error(SendSmsJobException)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/send_sms_job_spec.rb
@@ -38,7 +38,7 @@ module Decidim::ActionDelegator
       context "when code's result isn't 200" do
         let(:result) { "<xml><codigo>115</codigo><descripcion>Woopsie</descripcion></xml>" }
 
-        it "returns false" do
+        it "Raises SendSmsJobException" do
           expect { subject.perform_now(sender_name, mobile_phone_number, message) }.to raise_error(SendSmsJobException)
         end
       end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -29,6 +29,15 @@ module Decidim::ActionDelegator
         "/app/controllers/decidim/consultations/question_votes_controller.rb" => "69bf764e99dfcdae138613adbed28b84",
         "/app/forms/decidim/consultations/vote_form.rb" => "d2b69f479b61b32faf3b108da310081a"
       }
+    }, {
+      package: "decidim-verifications",
+      files: {
+        # views
+        "/app/views/decidim/verifications/sms/authorizations/new.html.erb" => "c8d91f5a2221c3f4b51ccd720ddb427e",
+
+        # monkeypatches
+        "/app/controllers/decidim/verifications/sms/authorizations_controller.rb" => "ad4a85dfad26a8cf9313b481b8e4872c"
+      }
     }
   ]
 

--- a/spec/services/decidim/action_delegator/sms_gateway_spec.rb
+++ b/spec/services/decidim/action_delegator/sms_gateway_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ActionDelegator
+  describe SmsGateway do
+    let(:subject) { described_class.new(mobile_phone_number, code) }
+    let(:mobile_phone_number) { "+12 345 678 901" }
+    let(:code) { "1a4s9b" }
+    let(:client) { double("client") }
+    let(:response) { double("response") }
+    let(:response_body) { { send_sms_response: { result: result } } }
+
+    describe "#deliver_code" do
+      before do
+        allow(Savon).to receive(:client).and_return(client)
+        allow(client).to receive(:call).and_return(response)
+        allow(response).to receive(:body).and_return(response_body)
+      end
+
+      context "when code's result is 200" do
+        let(:result) { "<xml><codigo>200</codigo><description>Went well</description></xml>" }
+
+        it "returns true" do
+          expect(subject.deliver_code).to eq(true)
+        end
+      end
+
+      context "when code's result isn't 200" do
+        let(:result) { "<xml><codigo>115</codigo><description>Woopsie</description></xml>" }
+
+        it "returns false" do
+          expect(subject.deliver_code).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decidim/action_delegator/sms_gateway_spec.rb
+++ b/spec/services/decidim/action_delegator/sms_gateway_spec.rb
@@ -19,7 +19,7 @@ module Decidim::ActionDelegator
       end
 
       context "when code's result is 200" do
-        let(:result) { "<xml><codigo>200</codigo><description>Went well</description></xml>" }
+        let(:result) { "<xml><codigo>200</codigo><descripcion>Went well</descripcion></xml>" }
 
         it "returns true" do
           expect(subject.deliver_code).to eq(true)
@@ -27,7 +27,7 @@ module Decidim::ActionDelegator
       end
 
       context "when code's result isn't 200" do
-        let(:result) { "<xml><codigo>115</codigo><description>Woopsie</description></xml>" }
+        let(:result) { "<xml><codigo>115</codigo><descripcion>Woopsie</descripcion></xml>" }
 
         it "returns false" do
           expect(subject.deliver_code).to eq(false)

--- a/spec/services/decidim/action_delegator/sms_gateway_spec.rb
+++ b/spec/services/decidim/action_delegator/sms_gateway_spec.rb
@@ -7,31 +7,11 @@ module Decidim::ActionDelegator
     let(:subject) { described_class.new(mobile_phone_number, code) }
     let(:mobile_phone_number) { "+12 345 678 901" }
     let(:code) { "1a4s9b" }
-    let(:client) { double("client") }
-    let(:response) { double("response") }
     let(:response_body) { { send_sms_response: { result: result } } }
 
     describe "#deliver_code" do
-      before do
-        allow(Savon).to receive(:client).and_return(client)
-        allow(client).to receive(:call).and_return(response)
-        allow(response).to receive(:body).and_return(response_body)
-      end
-
-      context "when code's result is 200" do
-        let(:result) { "<xml><codigo>200</codigo><descripcion>Went well</descripcion></xml>" }
-
-        it "returns true" do
-          expect(subject.deliver_code).to eq(true)
-        end
-      end
-
-      context "when code's result isn't 200" do
-        let(:result) { "<xml><codigo>115</codigo><descripcion>Woopsie</descripcion></xml>" }
-
-        it "returns false" do
-          expect(subject.deliver_code).to eq(false)
-        end
+      it "enqueues a SendSmsJob" do
+        expect { subject.deliver_code }.to have_enqueued_job(SendSmsJob)
       end
     end
   end


### PR DESCRIPTION
Integration between Decidim verification system and Som Connexió's sms gateway in order to verification via sms.

More context: https://github.com/coopdevs/decidim-coopcat/issues/34

## Setup

In order to use this new sms gateway you need to configure your application. In `config/initializers/decidim.rb` set:

```  config.sms_gateway_service = 'Decidim::ActionDelegator::SmsGateway'```

You'll need to set the following ENV vars:

```
SMS_USER=
SMS_PASS=
SMS_SENDER_NAME=
```

I'm not very fond of their name, maybe I could name it with a prefix that relates to the SMS Gateway service.