### PR TITLE
Link results to custom controller

### DIFF
--- a/app/views/layouts/decidim/admin/consultation.html.erb
+++ b/app/views/layouts/decidim/admin/consultation.html.erb
@@ -1,0 +1,36 @@
+<% content_for :secondary_nav do %>
+  <div class="secondary-nav secondary-nav--subnav">
+    <ul>
+      <%= public_page_link decidim_consultations.consultation_path(current_consultation) %>
+      <% if allowed_to? :update, :consultation, consultation: current_consultation %>
+        <li <% if is_active_link?(decidim_admin_consultations.edit_consultation_path(current_consultation)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.consultations_submenu"),
+                                    decidim_admin_consultations.edit_consultation_path(current_consultation) %>
+        </li>
+      <% end %>
+
+      <% if allowed_to? :read, :question %>
+        <li <% if is_active_link?(decidim_admin_consultations.consultation_questions_path(current_consultation)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("questions", scope: "decidim.admin.menu.consultations_submenu"),
+                                    decidim_admin_consultations.consultation_questions_path(current_consultation) %>
+        </li>
+        <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
+                                    decidim_admin_action_delegator.results_consultation_path(current_consultation) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to translated_attribute(current_consultation.title), decidim_consultations.consultation_path(current_consultation), target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
+<% end %>

--- a/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
@@ -11,20 +11,8 @@ module Decidim::ActionDelegator
 
     let!(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
     let!(:question) { create(:question, consultation: consultation) }
-    let!(:response) do
-      create(
-        :response,
-        question: question,
-        title: { "en" => "A", "ca" => "A", "es" => "A" }
-      )
-    end
-    let!(:other_response) do
-      create(
-        :response,
-        question: question,
-        title: { "en" => "B", "ca" => "B", "es" => "B" }
-      )
-    end
+    let!(:response) { create(:response, question: question, title: { "ca" => "A" }) }
+    let!(:other_response) { create(:response, question: question, title: { "ca" => "B" }) }
 
     let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
     let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -23,6 +23,7 @@ module Decidim::ActionDelegator
         "/app/views/decidim/consultations/questions/_vote_modal.html.erb" => "b23948e4ed7e0360a09faef326bc3664",
         "/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb" => "7eb753c457e9a5adc6c16efd155ba434",
         "/app/views/decidim/consultations/admin/consultations/results.html.erb" => "1a2f7afd79b20b1fcf66bdece660e8ae",
+        "/app/views/layouts/decidim/admin/consultation.html.erb" => "7f70f790cf474389f327528136d366a3",
 
         # monkeypatches
         "/app/commands/decidim/consultations/vote_question.rb" => "8d89031039a1ba2972437d13687a72b5",

--- a/spec/serializers/decidim/action_delegator/consultation_results_serializer_spec.rb
+++ b/spec/serializers/decidim/action_delegator/consultation_results_serializer_spec.rb
@@ -8,7 +8,7 @@ module Decidim::ActionDelegator
     let(:result) do
       double(
         :result,
-        title: { "en" => "A", "ca" => "A", "es" => "A" },
+        title: { "ca" => "A" },
         membership_type: "consumer",
         membership_weight: 2,
         votes_count: 2
@@ -18,7 +18,7 @@ module Decidim::ActionDelegator
     describe "#serialize" do
       it "includes all attributes" do
         expect(subject.serialize).to eq(
-          title: translated(result.title),
+          title: "A",
           membership_type: "consumer",
           votes_count: 2,
           membership_weight: 2

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -9,20 +9,8 @@ describe "Admin manages consultation results", type: :system do
   let(:total_votes) { I18n.t("decidim.admin.consultations.results.total_votes", count: votes) }
 
   let!(:question) { create(:question, consultation: consultation) }
-  let!(:response) do
-    create(
-      :response,
-      question: question,
-      title: { "en" => "A", "ca" => "A", "es" => "A" }
-    )
-  end
-  let!(:other_response) do
-    create(
-      :response,
-      question: question,
-      title: { "en" => "B", "ca" => "B", "es" => "B" }
-    )
-  end
+  let!(:response) { create(:response, question: question, title: { "ca" => "A" }) }
+  let!(:other_response) { create(:response, question: question, title: { "ca" => "B" }) }
 
   let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
   let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -34,6 +34,18 @@ describe "Admin manages consultation results", type: :system do
     login_as user, scope: :user
   end
 
+  context "when in the consultation page" do
+    let!(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+
+    before { visit decidim_admin_consultations.edit_consultation_path(consultation) }
+
+    it "enables navigating to the results page" do
+      click_link I18n.t("decidim.admin.menu.consultations_submenu.results")
+
+      expect(page).to have_current_path(decidim_admin_action_delegator.results_consultation_path(consultation))
+    end
+  end
+
   context "when viewing a finished consultation with votes" do
     let!(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
 


### PR DESCRIPTION
Without this, `decidim-consultations`'s `ConsultationsController` gets called and so `@questions` is not defined which causes our `results.html.erb` view to fail with a `ActionView::Template::Error Decidim::Consultations::Admin::ConsultationsController#results undefined method `each' for nil:NilClass`.