### PR TITLE
Fix delegation vote after voting

### DIFF
--- a/app/permissions/decidim/action_delegator/consultations_permissions_extension.rb
+++ b/app/permissions/decidim/action_delegator/consultations_permissions_extension.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    module ConsultationsPermissionsExtension
+      # Overrides Decidim::Consultations::Permissions to account for delegation votes
+      def allowed_public_action?
+        return unless permission_action.scope == :public
+        return unless permission_action.subject == :question
+
+        # check if question has been limited by admins first
+        return unless authorized? :vote
+
+        case permission_action.action
+        when :vote
+          toggle_allow(question.can_be_voted_by?(user) || can_be_delegated?(user))
+        when :unvote
+          toggle_allow(question.can_be_unvoted_by?(user))
+        end
+      end
+
+      def can_be_delegated?(user)
+        Delegation.granted_to?(user, question.consultation)
+      end
+    end
+  end
+end

--- a/lib/decidim/action_delegator/engine.rb
+++ b/lib/decidim/action_delegator/engine.rb
@@ -40,6 +40,10 @@ module Decidim
                     active: :exact
         end
       end
+
+      initializer "decidim_action_delegator.permissions" do
+        Decidim::Consultations::Permissions.prepend(ConsultationsPermissionsExtension)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #55.

The root cause is that Consultation's permissions check whether there's a vote for that question and user already. If there was, it won't let you vote again. In our case, we also need to account for any available delegation for the current user.

It's not easy to extend decidim's permissions from an engine and this is the most cost-effective solution I found.