### PR TITLE
Check question permissions with grantee only

### DIFF
--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -2,7 +2,7 @@
 
 Decidim::Consultations::QuestionVotesController.class_eval do
   def destroy
-    enforce_permission_to_unvote :question, question: current_question
+    enforce_permission_to_unvote
     Decidim::Consultations::UnvoteQuestion.call(current_question, delegation.present? ? delegation.granter : current_user) do
       on(:ok) do
         current_question.reload
@@ -17,22 +17,15 @@ Decidim::Consultations::QuestionVotesController.class_eval do
     @delegation ||= Decidim::ActionDelegator::Delegation.find_by(id: params[:decidim_consultations_delegation_id])
   end
 
-  def enforce_permission_to_unvote(subject, extra_context = {})
+  def enforce_permission_to_unvote
     if delegation.blank?
       enforce_permission_to :unvote, :question, question: current_question
     else
-      if Rails.env.development?
-        Rails.logger.debug "==========="
-        Rails.logger.debug [permission_scope, :unvote, subject, permission_class_chain].map(&:inspect).join("\n")
-        Rails.logger.debug "==========="
-      end
-
       raise Decidim::ActionForbidden unless allowed_to?(
-        :unvote,
-        subject,
-        extra_context,
-        [Decidim::Consultations::Permissions, Decidim::Admin::Permissions, Decidim::Permissions],
-        delegation.granter
+        :unvote_delegation,
+        :question,
+        { question: current_question, delegation: delegation },
+        [Decidim::ActionDelegator::Permissions, Decidim::Admin::Permissions, Decidim::Permissions]
       )
     end
   end

--- a/app/views/decidim/action_delegator/_delegations_modal.html.erb
+++ b/app/views/decidim/action_delegator/_delegations_modal.html.erb
@@ -40,7 +40,7 @@
                 </div>
               <% end %>
             <% elsif signed_in? && question.consultation.active? %>
-              <% if allowed_to? :unvote, :question, { question: question }, [Decidim::Consultations::Permissions, Decidim::Admin::Permissions, Decidim::Permissions], delegation.granter %>
+              <% if allowed_to? :unvote_delegation, :question, { question: question, delegation: delegation }, [Decidim::ActionDelegator::Permissions, Decidim::Admin::Permissions, Decidim::Permissions] %>
                 <%= button_to decidim_consultations.question_question_votes_path(question),
                               method: :delete,
                               remote: true,
@@ -53,7 +53,7 @@
                     <%= t("questions.vote_button.already_voted", scope: "decidim") %>
                   </div>
                 <% end %>
-              <% elsif allowed_to? :vote, :question, { question: question }, [Decidim::Consultations::Permissions, Decidim::Admin::Permissions, Decidim::Permissions], delegation.granter %>
+              <% elsif allowed_to? :vote_delegation, :question, { question: question, delegation: delegation }, [Decidim::ActionDelegator::Permissions, Decidim::Admin::Permissions, Decidim::Permissions] %>
                 <% if question.multiple? %>
                   <%= link_to decidim_consultations.question_question_multiple_votes_path(question),
                               class: "button expanded",

--- a/spec/permissions/decidim/action_delegator/delegation_permissions_spec.rb
+++ b/spec/permissions/decidim/action_delegator/delegation_permissions_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::Permissions do # rubocop:disable RSpec/FilePath
+  subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+  let(:permission_action) { Decidim::PermissionAction.new(action) }
+  let(:context) { {} }
+
+  let(:organization) { create(:organization) }
+  let(:consultation) { create(:consultation, :active, organization: organization) }
+  let(:question) { create(:question, consultation: consultation) }
+  let(:setting) { create(:setting, consultation: consultation) }
+  let(:granter) { create(:user, :confirmed, organization: organization) }
+  let(:user) { create(:user, organization: organization) }
+  let(:delegation) { create(:delegation, setting: setting, granter: granter, grantee: user) }
+
+  let(:permissions) { { "vote" => { "authorization_handlers" => { "dummy_authorization_workflow" => {} } } } }
+
+  before do
+    question.build_resource_permission.update!(permissions: permissions)
+  end
+
+  context "when voting a delegation" do
+    let(:action) do
+      { scope: :public, action: :vote_delegation, subject: :question }
+    end
+    let(:context) { { question: question, delegation: delegation } }
+
+    context "and the grantee is verified" do
+      before do
+        create(:authorization, name: "dummy_authorization_workflow", user: user, granted_at: Time.zone.now)
+      end
+
+      context "and it wasn't voted yet" do
+        it { is_expected.to eq(true) }
+      end
+
+      context "and it was already voted" do
+        before { create(:vote, author: granter, question: question) }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "and the grantee is not verified" do
+      it_behaves_like "permission is not set"
+    end
+
+    context "and the user is not the grantee" do
+      let(:other_user) { create(:user, organization: organization) }
+      let(:delegation) { create(:delegation, setting: setting, granter: granter, grantee: other_user) }
+
+      before do
+        Decidim::Authorization.create!(name: "dummy_authorization_workflow", decidim_user_id: other_user.id, granted_at: Time.zone.now)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  context "when unvoting a delegation" do
+    let(:action) do
+      { scope: :public, action: :unvote_delegation, subject: :question }
+    end
+    let(:context) { { question: question, delegation: delegation } }
+
+    let!(:vote) { create(:vote, author: granter, question: question) }
+
+    context "when the grantee is verified" do
+      before do
+        create(:authorization, name: "dummy_authorization_workflow", user: user, granted_at: Time.zone.now)
+      end
+
+      context "and it was already voted" do
+        it { is_expected.to eq(true) }
+      end
+
+      context "and it wasn't voted yet" do
+        before { vote.destroy }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "when the grantee is not verified" do
+      it_behaves_like "permission is not set"
+    end
+
+    context "when the user is not the grantee" do
+      let(:other_user) { create(:user, organization: organization) }
+      let(:delegation) { create(:delegation, setting: setting, granter: granter, grantee: other_user) }
+
+      before do
+        Decidim::Authorization.create!(name: "dummy_authorization_workflow", decidim_user_id: other_user.id, granted_at: Time.zone.now)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
The only person actually present in the assembly and voting is the grantee. So, if that person is verified so are the votes they place on behalf of others.
    
This is done by decoupling permissions of a delegated vote from a regular one. The former needs to check information from the delegation whereas, the latter doesn't.
    
We also ensure the grantee is who performs the vote/unvote. To do that it was simpler to consider the permissions `user` the one performing the action (current_user) and simply deal with the delegation's grantee/granter to check the permissions. This saves us from having to pass in the `user` argument on the calls to `allowed_to?`.