### PR TITLE
Do not fetch delegations when no user is logged in

### DIFF
--- a/app/views/decidim/action_delegator/_callout.html.erb
+++ b/app/views/decidim/action_delegator/_callout.html.erb
@@ -1,4 +1,4 @@
-<% if Decidim::ActionDelegator::Delegation.granted_to?(current_user, consultation) %>
+<% if signed_in? && Decidim::ActionDelegator::Delegation.granted_to?(current_user, consultation) %>
   <div class="delegation-callout callout warning is-hidden">
     <p><%= t "action_delegator.delegations_modal.callout", scope: "decidim" %> <span class="delegation-callout-message"></span></p>
   </div>

--- a/app/views/decidim/action_delegator/_delegations_modal.html.erb
+++ b/app/views/decidim/action_delegator/_delegations_modal.html.erb
@@ -12,7 +12,7 @@
   <div class="card card--secondary">
     <div class="card__content">
 
-      <% Decidim::ActionDelegator::ConsultationDelegations.for(question.consultation, current_user).each do |delegation| %>
+      <% signed_in? && Decidim::ActionDelegator::ConsultationDelegations.for(question.consultation, current_user).each do |delegation| %>
         <div class="row">
           <div class="columns medium-5 medium-offset-1">
             <%= delegation.granter.name %>

--- a/app/views/decidim/action_delegator/_link_to_question.html.erb
+++ b/app/views/decidim/action_delegator/_link_to_question.html.erb
@@ -1,4 +1,4 @@
-<% if Decidim::ActionDelegator::Delegation.granted_to?(current_user, question.consultation) %>
+<% if signed_in? && Decidim::ActionDelegator::Delegation.granted_to?(current_user, question.consultation) %>
   <div class="delegations-notice flex--cc">
     <%= link_to t("action_delegator.delegations.link", scope: "decidim"), decidim_consultations.question_path(question) %>
   </div>

--- a/spec/system/decidim/action_delegator/delegations_spec.rb
+++ b/spec/system/decidim/action_delegator/delegations_spec.rb
@@ -10,6 +10,17 @@ describe "Delegation vote", type: :system do
     let(:consultation) { create(:consultation, :active, organization: organization) }
     let(:user) { create(:user, :confirmed, organization: organization) }
 
+    context "and unauthenticated user" do
+      before do
+        switch_to_host(organization.host)
+      end
+
+      it "renders the question page" do
+        visit decidim_consultations.question_path(question)
+        expect(page).to have_content(I18n.t("decidim.questions.vote_button.vote").upcase)
+      end
+    end
+
     context "and authenticated user" do
       let!(:response) { create :response, question: question }
       let(:setting) { create(:setting, consultation: consultation) }


### PR DESCRIPTION
This fixes the root cause of the following error reported by Sentry

![Screenshot from 2020-10-23 13-09-49](https://user-images.githubusercontent.com/762088/96996959-17189580-1531-11eb-8388-60b522aea13b.png)

when not logged in, there is no `current_user` we can use to fetch her delegations so we can't render them but we should still show the page as usual.