### PR TITLE
Record delegated votes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,33 @@ TWILIO_AUTH_TOKEN # Token from your Twilio account
 SMS_SENDER # Twilio's phone number. You need to purchase one there with SMS capability.
 ```
 
+### Track delegated votes and unvotes
+
+Votes and revocations done on behalf of other members are tracked through the
+`versions` table using `PaperTrail`. This enables fetching a log of actions
+involving a particular delegation or consultation for auditing purposes. This
+keeps out regular votes and unvotes.
+
+When performing votes and unvotes of delegations you'll see things like the
+following in your `versions` table:
+
+```sql
+  id  |          item_type           | item_id |  event  | whodunnit | decidim_action_delegator_delegation_id 
+------+------------------------------+---------+---------+-----------+----------------------------------------
+ 2019 | Decidim::Consultations::Vote |     143 | destroy | 1         |                                     22
+ 2018 | Decidim::Consultations::Vote |     143 | create  | 1         |                                     22
+ 2017 | Decidim::Consultations::Vote |     142 | create  | 1         |                                     23
+ 2016 | Decidim::Consultations::Vote |     138 | destroy | 1         |                                     23
+```
+
+Note that the `item_type` is `Decidim::Consultations::Vote` and `whoddunit`
+refers to a `Decidim::User` record. This enables joining `versions` and
+`decidim_users` tables although this doesn't follow Decidim's convention of
+using gids, such as `gid://decidim/Decidim::User/1`.
+
+You can use `Decidim::ActionDelegato::DelegatedVotes::Versions` query object for
+that matter.
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).

--- a/app/commands/decidim/action_delegator/vote_delegation.rb
+++ b/app/commands/decidim/action_delegator/vote_delegation.rb
@@ -9,6 +9,7 @@ module Decidim
       end
 
       def call
+        PaperTrail.request.controller_info = { decidim_action_delegator_delegation_id: context.delegation.id }
         WhodunnitVote.new(build_vote, context.current_user)
       end
 

--- a/app/commands/decidim/action_delegator/vote_delegation.rb
+++ b/app/commands/decidim/action_delegator/vote_delegation.rb
@@ -4,22 +4,22 @@ module Decidim
   module ActionDelegator
     class VoteDelegation
       def initialize(form)
-        @form = form
-        @delegation = form.context.delegation
+        @context = form.context
+        @response = form.response
       end
 
       def call
-        build_vote
+        WhodunnitVote.new(build_vote, context.current_user)
       end
 
       private
 
-      attr_reader :form, :delegation
+      attr_reader :context, :response
 
       def build_vote
-        form.context.current_question.votes.build(
-          author: delegation.granter,
-          response: form.response
+        context.current_question.votes.build(
+          author: context.delegation.granter,
+          response: response
         )
       end
     end

--- a/app/commands/decidim/action_delegator/vote_delegation.rb
+++ b/app/commands/decidim/action_delegator/vote_delegation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class VoteDelegation
+      def initialize(form)
+        @form = form
+        @delegation = form.context.delegation
+      end
+
+      def call
+        build_vote
+      end
+
+      private
+
+      attr_reader :form, :delegation
+
+      def build_vote
+        form.context.current_question.votes.build(
+          author: delegation.granter,
+          response: form.response
+        )
+      end
+    end
+  end
+end

--- a/app/models/decidim/action_delegator/unversioned_vote.rb
+++ b/app/models/decidim/action_delegator/unversioned_vote.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class UnversionedVote < SimpleDelegator
+      def save
+        PaperTrail.request(enabled: false) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/app/models/decidim/action_delegator/whodunnit_vote.rb
+++ b/app/models/decidim/action_delegator/whodunnit_vote.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class WhodunnitVote < DelegateClass(Decidim::Consultations::Vote)
+      def initialize(vote, user)
+        @user = user
+        super(vote)
+      end
+
+      def save
+        PaperTrail.request(whodunnit: user.id) do
+          super
+        end
+      end
+
+      private
+
+      attr_reader :user
+    end
+  end
+end

--- a/app/overrides/commands/decidim/consultations/vote_question.rb
+++ b/app/overrides/commands/decidim/consultations/vote_question.rb
@@ -8,10 +8,11 @@ Decidim::Consultations::VoteQuestion.class_eval do
       form.context.delegation = delegation
       Decidim::ActionDelegator::VoteDelegation.new(form).call
     else
-      form.context.current_question.votes.build(
+      vote = form.context.current_question.votes.build(
         author: form.context.current_user,
         response: form.response
       )
+      Decidim::ActionDelegator::UnversionedVote.new(vote)
     end
   end
 

--- a/app/overrides/commands/decidim/consultations/vote_question.rb
+++ b/app/overrides/commands/decidim/consultations/vote_question.rb
@@ -4,11 +4,15 @@ Decidim::Consultations::VoteQuestion.class_eval do
   private
 
   def build_vote
-    author = delegation ? delegation.granter : form.context.current_user
-    form.context.current_question.votes.build(
-      author: author,
-      response: form.response
-    )
+    if delegation
+      form.context.delegation = delegation
+      Decidim::ActionDelegator::VoteDelegation.new(form).call
+    else
+      form.context.current_question.votes.build(
+        author: form.context.current_user,
+        response: form.response
+      )
+    end
   end
 
   def delegation

--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -3,7 +3,9 @@
 Decidim::Consultations::QuestionVotesController.class_eval do
   def destroy
     enforce_permission_to_unvote
-    Decidim::Consultations::UnvoteQuestion.call(current_question, delegation.present? ? delegation.granter : current_user) do
+
+    user = delegation.blank? ? current_user : delegation.granter
+    Decidim::Consultations::UnvoteQuestion.call(current_question, user) do
       on(:ok) do
         current_question.reload
         render :update_vote_button

--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -6,7 +6,7 @@ Decidim::Consultations::QuestionVotesController.class_eval do
 
     user = delegation.blank? ? current_user : delegation.granter
 
-    PaperTrail.request(enabled: delegation.present?) do
+    PaperTrail.request(enabled: delegation.present?, whodunnit: current_user.id) do
       Decidim::Consultations::UnvoteQuestion.call(current_question, user) do
         on(:ok) do
           current_question.reload

--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -6,10 +6,12 @@ Decidim::Consultations::QuestionVotesController.class_eval do
 
     user = delegation.blank? ? current_user : delegation.granter
 
-    Decidim::Consultations::UnvoteQuestion.call(current_question, user) do
-      on(:ok) do
-        current_question.reload
-        render :update_vote_button
+    PaperTrail.request(enabled: delegation.present?) do
+      Decidim::Consultations::UnvoteQuestion.call(current_question, user) do
+        on(:ok) do
+          current_question.reload
+          render :update_vote_button
+        end
       end
     end
   end

--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -5,6 +5,7 @@ Decidim::Consultations::QuestionVotesController.class_eval do
     enforce_permission_to_unvote
 
     user = delegation.blank? ? current_user : delegation.granter
+
     Decidim::Consultations::UnvoteQuestion.call(current_question, user) do
       on(:ok) do
         current_question.reload

--- a/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
+++ b/app/overrides/controllers/decidim/consultations/question_votes_controller.rb
@@ -18,6 +18,14 @@ Decidim::Consultations::QuestionVotesController.class_eval do
 
   private
 
+  def info_for_paper_trail
+    if delegation.present?
+      { decidim_action_delegator_delegation_id: delegation.id }
+    else
+      {}
+    end
+  end
+
   def delegation
     @delegation ||= Decidim::ActionDelegator::Delegation.find_by(id: params[:decidim_consultations_delegation_id])
   end

--- a/app/overrides/models/decidim/consultations/vote.rb
+++ b/app/overrides/models/decidim/consultations/vote.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Decidim::Consultations::Vote.class_eval do
+  has_paper_trail(
+    meta: {
+      decidim_action_delegator_delegation_id: proc { |vote| vote.delegation&.id }
+    }
+  )
+
+  # TODO: What if there is a delegation but it wasn't used? we can't know it here. The only way is
+  # by passing that information from the controller.
+  def delegation
+    Decidim::ActionDelegator::Delegation
+      .joins(setting: :consultation)
+      .where(decidim_consultations: { id: question.consultation.id })
+      .find_by(granter_id: decidim_author_id)
+  end
+end

--- a/app/overrides/models/decidim/consultations/vote.rb
+++ b/app/overrides/models/decidim/consultations/vote.rb
@@ -1,18 +1,5 @@
 # frozen_string_literal: true
 
 Decidim::Consultations::Vote.class_eval do
-  has_paper_trail(
-    meta: {
-      decidim_action_delegator_delegation_id: proc { |vote| vote.delegation&.id }
-    }
-  )
-
-  # TODO: What if there is a delegation but it wasn't used? we can't know it here. The only way is
-  # by passing that information from the controller.
-  def delegation
-    Decidim::ActionDelegator::Delegation
-      .joins(setting: :consultation)
-      .where(decidim_consultations: { id: question.consultation.id })
-      .find_by(granter_id: decidim_author_id)
-  end
+  has_paper_trail
 end

--- a/app/queries/decidim/action_delegator/delegated_votes_versions.rb
+++ b/app/queries/decidim/action_delegator/delegated_votes_versions.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    # Returns all PaperTrail versions of a consultation's delegated votes for auditing purposes.
+    # It is intended to be used to easily fetch this data when a judge ask us so.
+    class DelegatedVotesVersions
+      def initialize(consultation)
+        @consultation = consultation
+      end
+
+      def query
+        statement = <<-SQL.strip_heredoc
+          SELECT *
+          FROM versions
+          INNER JOIN decidim_action_delegator_delegations
+            ON decidim_action_delegator_delegations.id = versions.decidim_action_delegator_delegation_id
+          INNER JOIN decidim_action_delegator_settings
+            ON decidim_action_delegator_settings.id = decidim_action_delegator_delegations.decidim_action_delegator_setting_id
+          WHERE decidim_action_delegator_settings.decidim_consultation_id = #{consultation.id}
+        SQL
+
+        ActiveRecord::Base.connection.execute(statement).to_a
+      end
+
+      private
+
+      attr_reader :consultation
+    end
+  end
+end

--- a/db/migrate/20201030164808_add_delegation_id_to_versions.rb
+++ b/db/migrate/20201030164808_add_delegation_id_to_versions.rb
@@ -3,5 +3,6 @@
 class AddDelegationIdToVersions < ActiveRecord::Migration[5.2]
   def change
     add_column :versions, :decidim_action_delegator_delegation_id, :integer, null: true, default: nil
+    add_index :versions, :decidim_action_delegator_delegation_id
   end
 end

--- a/db/migrate/20201030164808_add_delegation_id_to_versions.rb
+++ b/db/migrate/20201030164808_add_delegation_id_to_versions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDelegationIdToVersions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :versions, :decidim_action_delegator_delegation_id, :integer, null: true, default: nil
+  end
+end

--- a/lib/decidim/action_delegator/engine.rb
+++ b/lib/decidim/action_delegator/engine.rb
@@ -26,8 +26,6 @@ module Decidim
           Dir.glob(Decidim::ActionDelegator::Engine.root + "app/overrides/**/*.rb").each do |c|
             require_dependency(c)
           end
-
-          Decidim::Consultations::Vote.has_paper_trail
         end
       end
 

--- a/lib/decidim/action_delegator/engine.rb
+++ b/lib/decidim/action_delegator/engine.rb
@@ -26,6 +26,8 @@ module Decidim
           Dir.glob(Decidim::ActionDelegator::Engine.root + "app/overrides/**/*.rb").each do |c|
             require_dependency(c)
           end
+
+          Decidim::Consultations::Vote.has_paper_trail
         end
       end
 

--- a/lib/decidim/action_delegator/test/factories.rb
+++ b/lib/decidim/action_delegator/test/factories.rb
@@ -5,9 +5,9 @@ require "decidim/consultations/test/factories"
 
 FactoryBot.define do
   factory :delegation, class: "Decidim::ActionDelegator::Delegation" do
-    granter factory: :user
-    grantee factory: :user
     setting
+    granter { association :user, organization: setting.consultation.organization }
+    grantee { association :user, organization: setting.consultation.organization }
   end
 
   factory :setting, class: "Decidim::ActionDelegator::Setting" do

--- a/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
+++ b/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::VoteDelegation do
+  subject { described_class.new(form) }
+
+  let(:organization) { build(:organization) }
+  let(:consultation) { build(:consultation, :active, organization: organization) }
+  let(:setting) { build(:setting, consultation: consultation) }
+  let(:delegation) { build(:delegation, setting: setting) }
+  let(:question) { build(:question, :published, consultation: consultation) }
+  let(:response) { build(:response, question: question) }
+
+  let(:context) { double(:context, delegation: delegation, current_question: question) }
+  let(:form) { instance_double(Decidim::Consultations::VoteForm, context: context, response: response) }
+
+  describe "#call" do
+    it "builds a vote with the granter as author" do
+      vote = subject.call
+      expect(vote.author).to eq(delegation.granter)
+    end
+
+    it "builds a vote with the response taken from the form" do
+      vote = subject.call
+      expect(vote.response).to eq(form.response)
+    end
+
+    it "builds a valid vote" do
+      vote = subject.call
+      expect(vote).to be_valid
+    end
+  end
+end

--- a/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
+++ b/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::ActionDelegator::VoteDelegation do
   let(:question) { build(:question, :published, consultation: consultation) }
   let(:response) { build(:response, question: question) }
 
-  let(:context) { double(:context, delegation: delegation, current_question: question) }
+  let(:context) { double(:context, delegation: delegation, current_question: question, current_user: delegation.grantee) }
   let(:form) { instance_double(Decidim::Consultations::VoteForm, context: context, response: response) }
 
   describe "#call" do
@@ -29,6 +29,13 @@ describe Decidim::ActionDelegator::VoteDelegation do
     it "builds a valid vote" do
       vote = subject.call
       expect(vote).to be_valid
+    end
+
+    it "tracks who performed the vote", versioning: true do
+      vote = subject.call
+      vote.save
+
+      expect(vote.versions.last.whodunnit).to eq(context.current_user.id.to_s)
     end
   end
 end

--- a/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
+++ b/spec/commands/decidim/action_delegator/vote_delegation_spec.rb
@@ -37,5 +37,15 @@ describe Decidim::ActionDelegator::VoteDelegation do
 
       expect(vote.versions.last.whodunnit).to eq(context.current_user.id.to_s)
     end
+
+    it "tracks the delegation the vote is related to", versioning: true do
+      delegation.save
+      question.save
+
+      vote = subject.call
+      vote.save
+
+      expect(vote.versions.last.decidim_action_delegator_delegation_id).to eq(delegation.id)
+    end
   end
 end

--- a/spec/commands/decidim/consultations/vote_question_spec.rb
+++ b/spec/commands/decidim/consultations/vote_question_spec.rb
@@ -51,10 +51,9 @@ module Decidim
         end
 
         describe "originator", versioning: true do
-          it "tracks who was responsible for the action" do
-            subject.call
-            vote = Vote.last
-            expect(vote.paper_trail.originator).to be_nil
+          it "does not track who was responsible for the action" do
+            expect { subject.call }
+              .not_to change(PaperTrail::Version.where(item_type: "Decidim::Consultations::Vote"), :count)
           end
         end
 

--- a/spec/commands/decidim/consultations/vote_question_spec.rb
+++ b/spec/commands/decidim/consultations/vote_question_spec.rb
@@ -50,6 +50,14 @@ module Decidim
           end.to change(response, :votes_count).by(1)
         end
 
+        describe "originator", versioning: true do
+          it "tracks who was responsible for the action" do
+            subject.call
+            vote = Vote.last
+            expect(vote.paper_trail.originator).to be_nil
+          end
+        end
+
         context "when there is a delegation available" do
           let(:setting) { create(:setting, consultation: consultation) }
           let(:granter) { create(:user, organization: organization) }
@@ -71,6 +79,14 @@ module Decidim
             expect do
               subject.call
             end.to change(Vote.where(author: delegation.granter), :count).by(1)
+          end
+
+          describe "originator", versioning: true do
+            it "tracks who was responsible for the action" do
+              subject.call
+              vote = Vote.last
+              expect(vote.paper_trail.originator).to eq(delegation.grantee.id.to_s)
+            end
           end
         end
       end

--- a/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
+++ b/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Consultations
+    describe QuestionVotesController, type: :controller do
+      routes { Decidim::Consultations::Engine.routes }
+
+      let(:organization) { create :organization }
+      let(:user) { create(:user, :confirmed, organization: organization) }
+
+      before do
+        request.env["decidim.current_organization"] = organization
+        sign_in user
+      end
+
+      describe "#destroy" do
+        let(:consultation) { create(:consultation, organization: organization) }
+        let(:question) { create(:question, consultation: consultation) }
+        let(:setting) { create(:setting, consultation: consultation) }
+
+        context "when a delegation is specified" do
+          let(:delegation) { create(:delegation, setting: setting, grantee: user) }
+
+          before { create(:vote, author: delegation.granter, question: question) }
+
+          it "destroys the vote" do
+            delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
+            expect(response).to render_template(:update_vote_button)
+          end
+        end
+
+        context "when no delegation is specified" do
+          before { create(:vote, author: user, question: question) }
+
+          it "destroys the vote" do
+            delete :destroy, params: { question_slug: question.slug }, format: :js
+            expect(response).to render_template(:update_vote_button)
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
+++ b/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
@@ -20,7 +20,7 @@ module Decidim
         let(:question) { create(:question, consultation: consultation) }
         let(:setting) { create(:setting, consultation: consultation) }
 
-        context "when a delegation is specified" do
+        context "when a delegation is specified", versioning: true do
           let(:delegation) { create(:delegation, setting: setting, grantee: user) }
 
           before { create(:vote, author: delegation.granter, question: question) }
@@ -29,18 +29,28 @@ module Decidim
             delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
             expect(response).to render_template(:update_vote_button)
           end
+
+          it "creates a new version" do
+            expect do
+              delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
+            end.to change(PaperTrail::Version, :count)
+          end
         end
 
-        context "when no delegation is specified" do
+        context "when no delegation is specified", versioning: true do
           before { create(:vote, author: user, question: question) }
 
           it "destroys the vote" do
             delete :destroy, params: { question_slug: question.slug }, format: :js
             expect(response).to render_template(:update_vote_button)
           end
+
+          it "does not create a new version" do
+            expect { delete :destroy, params: { question_slug: question.slug }, format: :js }
+              .not_to change(PaperTrail::Version, :count)
+          end
         end
       end
     end
   end
 end
-

--- a/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
+++ b/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
@@ -22,7 +22,6 @@ module Decidim
 
         context "when a delegation is specified", versioning: true do
           let(:delegation) { create(:delegation, setting: setting, grantee: user) }
-
           let!(:vote) { create(:vote, author: delegation.granter, question: question) }
 
           it "destroys the vote" do
@@ -40,6 +39,12 @@ module Decidim
             delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
             version = vote.versions.last
             expect(version.whodunnit).to eq(user.id.to_s)
+          end
+
+          it "tracks the delegation the unvote is related to" do
+            delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
+            version = vote.versions.last
+            expect(version.decidim_action_delegator_delegation_id).to eq(delegation.id)
           end
         end
 

--- a/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
+++ b/spec/controllers/decidim/consultations/question_votes_controller_spec.rb
@@ -23,7 +23,7 @@ module Decidim
         context "when a delegation is specified", versioning: true do
           let(:delegation) { create(:delegation, setting: setting, grantee: user) }
 
-          before { create(:vote, author: delegation.granter, question: question) }
+          let!(:vote) { create(:vote, author: delegation.granter, question: question) }
 
           it "destroys the vote" do
             delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
@@ -34,6 +34,12 @@ module Decidim
             expect do
               delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
             end.to change(PaperTrail::Version, :count)
+          end
+
+          it "tracks who performed the unvote" do
+            delete :destroy, params: { question_slug: question.slug, decidim_consultations_delegation_id: delegation.id }, format: :js
+            version = vote.versions.last
+            expect(version.whodunnit).to eq(user.id.to_s)
           end
         end
 

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -28,6 +28,7 @@ module Decidim::ActionDelegator
 
         # monkeypatches
         "/app/commands/decidim/consultations/vote_question.rb" => "8d89031039a1ba2972437d13687a72b5",
+        "/app/models/decidim/consultations/vote.rb" => "c06286e3f7366d3a017bf69f1c9e3eef",
         "/app/controllers/decidim/consultations/question_votes_controller.rb" => "69bf764e99dfcdae138613adbed28b84",
         "/app/forms/decidim/consultations/vote_form.rb" => "d2b69f479b61b32faf3b108da310081a"
       }

--- a/spec/models/decidim/action_delegator/unversioned_vote_spec.rb
+++ b/spec/models/decidim/action_delegator/unversioned_vote_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe UnversionedVote do
+      subject(:unversioned_vote) { described_class.new(vote) }
+
+      let(:vote) { build(:vote) }
+
+      it "disables PaperTrail", versioning: true do
+        subject.save
+
+        expect(unversioned_vote.versions).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/decidim/action_delegator/whodunnit_vote_spec.rb
+++ b/spec/models/decidim/action_delegator/whodunnit_vote_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::WhodunnitVote do
+  describe "#save" do
+    subject { described_class.new(vote, user) }
+
+    let(:vote) { build(:vote) }
+    let(:user) { create(:user) }
+
+    it "sets PaperTrail's whodunnit" do
+      expect(PaperTrail).to receive(:request).with(whodunnit: user.id).and_yield
+      subject.save
+    end
+  end
+end

--- a/spec/models/decidim/consultations/vote_spec.rb
+++ b/spec/models/decidim/consultations/vote_spec.rb
@@ -10,6 +10,51 @@ module Decidim
       let(:vote) { build :vote }
 
       it { is_expected.to be_versioned }
+
+      describe "versions", versioning: true do
+        context "when the vote comes from a delegation" do
+          let(:organization) { create :organization }
+          let(:user) { create(:user, :confirmed, organization: organization) }
+
+          context "and the vote belongs to the delegation's consultation" do
+            let(:consultation) { create(:consultation, organization: organization) }
+            let(:question) { create(:question, consultation: consultation) }
+            let(:setting) { create(:setting, consultation: consultation) }
+
+            let(:delegation) { create(:delegation, setting: setting, granter: user) }
+            let!(:vote) { create(:vote, author: delegation.granter, question: question) }
+
+            it "stores the delegation id" do
+              version = vote.versions.last
+              expect(version.decidim_action_delegator_delegation_id).to eq(delegation.id)
+            end
+          end
+
+          context "and the vote does not belong to the delegation's consultation" do
+            let(:consultation) { create(:consultation, organization: organization) }
+            let(:setting) { create(:setting, consultation: consultation) }
+            let(:delegation) { create(:delegation, setting: setting, granter: user) }
+
+            let(:other_consultation) { create(:consultation, organization: organization) }
+            let(:other_question) { create(:question, consultation: other_consultation) }
+            let!(:vote) { create(:vote, author: delegation.granter, question: other_question) }
+
+            it "does not store the delegation id" do
+              version = vote.versions.last
+              expect(version.decidim_action_delegator_delegation_id).to be_nil
+            end
+          end
+        end
+
+        context "when the vote does not come from a delegation" do
+          let!(:vote) { create(:vote) }
+
+          it "does not store the delegation id" do
+            version = vote.versions.last
+            expect(version.decidim_action_delegator_delegation_id).to be_nil
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/decidim/consultations/vote_spec.rb
+++ b/spec/models/decidim/consultations/vote_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Consultations
+    describe Vote do
+      subject { vote }
+
+      let(:vote) { build :vote }
+
+      it { is_expected.to be_versioned }
+    end
+  end
+end

--- a/spec/models/decidim/consultations/vote_spec.rb
+++ b/spec/models/decidim/consultations/vote_spec.rb
@@ -10,51 +10,6 @@ module Decidim
       let(:vote) { build :vote }
 
       it { is_expected.to be_versioned }
-
-      describe "versions", versioning: true do
-        context "when the vote comes from a delegation" do
-          let(:organization) { create :organization }
-          let(:user) { create(:user, :confirmed, organization: organization) }
-
-          context "and the vote belongs to the delegation's consultation" do
-            let(:consultation) { create(:consultation, organization: organization) }
-            let(:question) { create(:question, consultation: consultation) }
-            let(:setting) { create(:setting, consultation: consultation) }
-
-            let(:delegation) { create(:delegation, setting: setting, granter: user) }
-            let!(:vote) { create(:vote, author: delegation.granter, question: question) }
-
-            it "stores the delegation id" do
-              version = vote.versions.last
-              expect(version.decidim_action_delegator_delegation_id).to eq(delegation.id)
-            end
-          end
-
-          context "and the vote does not belong to the delegation's consultation" do
-            let(:consultation) { create(:consultation, organization: organization) }
-            let(:setting) { create(:setting, consultation: consultation) }
-            let(:delegation) { create(:delegation, setting: setting, granter: user) }
-
-            let(:other_consultation) { create(:consultation, organization: organization) }
-            let(:other_question) { create(:question, consultation: other_consultation) }
-            let!(:vote) { create(:vote, author: delegation.granter, question: other_question) }
-
-            it "does not store the delegation id" do
-              version = vote.versions.last
-              expect(version.decidim_action_delegator_delegation_id).to be_nil
-            end
-          end
-        end
-
-        context "when the vote does not come from a delegation" do
-          let!(:vote) { create(:vote) }
-
-          it "does not store the delegation id" do
-            version = vote.versions.last
-            expect(version.decidim_action_delegator_delegation_id).to be_nil
-          end
-        end
-      end
     end
   end
 end

--- a/spec/queries/decidim/action_delegator/delegated_votes_versions_spec.rb
+++ b/spec/queries/decidim/action_delegator/delegated_votes_versions_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ActionDelegator
+  describe DelegatedVotesVersions do
+    subject { described_class.new(consultation) }
+
+    let(:organization) { create :organization }
+    let(:user) { create(:user, :confirmed, organization: organization) }
+
+    let(:consultation) { create(:consultation, organization: organization) }
+    let(:question) { create(:question, consultation: consultation) }
+    let(:setting) { create(:setting, consultation: consultation) }
+    let(:delegation) { create(:delegation, setting: setting, granter: user) }
+    let!(:vote) { create(:vote, author: delegation.granter, question: question) }
+
+    let!(:other_consultation) { create(:consultation, organization: organization) }
+    let(:other_question) { create(:question, consultation: other_consultation) }
+    let(:other_setting) { create(:setting, consultation: other_consultation) }
+    let!(:other_delegation) { create(:delegation, setting: other_setting, granter: user) }
+    let!(:other_vote) { create(:vote, author: other_delegation.granter, question: other_question) }
+
+    describe "#query", versioning: true do
+      it "enables fetching all versions related to a consultation" do
+        result = subject.query
+        version = vote.versions.last
+
+        expect(result.size).to eq(1)
+        expect(result.first).to include(version.attributes.slice(:id))
+      end
+    end
+  end
+end

--- a/spec/queries/decidim/action_delegator/delegated_votes_versions_spec.rb
+++ b/spec/queries/decidim/action_delegator/delegated_votes_versions_spec.rb
@@ -21,6 +21,15 @@ module Decidim::ActionDelegator
     let!(:other_delegation) { create(:delegation, setting: other_setting, granter: user) }
     let!(:other_vote) { create(:vote, author: other_delegation.granter, question: other_question) }
 
+    before do
+      PaperTrail::Version.create!(
+        item_type: "Decidim::Consultations::Vote",
+        item_id: vote.id,
+        event: "create",
+        decidim_action_delegator_delegation_id: delegation.id
+      )
+    end
+
     describe "#query", versioning: true do
       it "enables fetching all versions related to a consultation" do
         result = subject.query


### PR DESCRIPTION
Closes #66 

This keeps track of every change on a delegated vote in the `versions` table. We'll have things like:

```sql
  id  |          item_type           | item_id |  event  | whodunnit | decidim_action_delegator_delegation_id 
------+------------------------------+---------+---------+-----------+----------------------------------------
 2019 | Decidim::Consultations::Vote |     143 | destroy | 1         |                                     22
 2018 | Decidim::Consultations::Vote |     143 | create  | 1         |                                     22
 2017 | Decidim::Consultations::Vote |     142 | create  | 1         |                                     23
 2016 | Decidim::Consultations::Vote |     138 | destroy | 1         |                                     23
```
(some columns were excluded from the output)

## Missing
- [x] whodunnit
- [x] unvotes
- [x] Enable fetching versions for a consultation
- [x] Pass delegation from controller