### PR TITLE
Filter out non-direct-verifications authorizations

### DIFF
--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -33,6 +33,7 @@ module Decidim
             metadata_field_with_alias(:membership_weight),
             "COUNT(*) AS votes_count"
           )
+          .where(decidim_authorizations: { name: "direct_verifications" })
           .order(:title, :membership_type, membership_weight: :desc)
           .order("votes_count DESC")
       end

--- a/lib/decidim/action_delegator/test/factories.rb
+++ b/lib/decidim/action_delegator/test/factories.rb
@@ -15,3 +15,11 @@ FactoryBot.define do
     consultation
   end
 end
+
+FactoryBot.modify do
+  factory :authorization, class: "Decidim::Authorization" do
+    trait :direct_verification do
+      name { "direct_verifications" }
+    end
+  end
+end

--- a/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
@@ -26,11 +26,11 @@ module Decidim::ActionDelegator
       question.votes.create(author: another_user, response: response)
       question.votes.create(author: yet_another_user, response: other_response)
 
-      create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
-      create(:authorization, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
-      create(:authorization, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+      create(:authorization, :direct_verification, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
+      create(:authorization, :direct_verification, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
+      create(:authorization, :direct_verification, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
 
-      create(:authorization, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+      create(:authorization, :direct_verification, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
     end
 
     describe "queue" do

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -18,8 +18,8 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
     question.votes.create(author: user, response: response)
     question.votes.create(author: other_user, response: response)
 
-    create(:authorization, user: user, metadata: auth_metadata)
-    create(:authorization, user: other_user, metadata: other_auth_metadata)
+    create(:authorization, :direct_verification, user: user, metadata: auth_metadata)
+    create(:authorization, :direct_verification, user: other_user, metadata: other_auth_metadata)
   end
 
   describe "#query" do
@@ -78,7 +78,7 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
         create(:authorization, user: user, metadata: {})
       end
 
-      it "returns an extra vote" do
+      it "only considers direct_verifications authorizations" do
         result = subject.query
 
         expect(result.first.membership_type).to eq("consumer")
@@ -89,9 +89,7 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
         expect(result.second.membership_weight).to eq("2")
         expect(result.second.votes_count).to eq(1)
 
-        expect(result.third.membership_type).to be_nil
-        expect(result.third.membership_weight).to be_nil
-        expect(result.third.votes_count).to eq(1)
+        expect(result.third).to be_nil
       end
     end
   end

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -69,5 +69,30 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
         expect(result.second.votes_count).to eq(1)
       end
     end
+
+    context "when users have multiple authorizations" do
+      let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+      let(:other_auth_metadata) { { membership_type: "consumer", membership_weight: 2 } }
+
+      before do
+        create(:authorization, user: user, metadata: {})
+      end
+
+      it "returns an extra vote" do
+        result = subject.query
+
+        expect(result.first.membership_type).to eq("consumer")
+        expect(result.first.membership_weight).to eq("2")
+        expect(result.first.votes_count).to eq(1)
+
+        expect(result.second.membership_type).to eq("producer")
+        expect(result.second.membership_weight).to eq("2")
+        expect(result.second.votes_count).to eq(1)
+
+        expect(result.third.membership_type).to be_nil
+        expect(result.third.membership_weight).to be_nil
+        expect(result.third.votes_count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -83,6 +83,41 @@ describe "Admin manages consultation results", type: :system do
       expect(nth_row(4).find(".votes-count")).to have_content(1)
     end
 
+    context "when an author has multiple authorizations" do
+      before do
+        create(:authorization, user: user, metadata: {})
+      end
+
+      it "shows an odd row" do
+        visit decidim_admin_action_delegator.results_consultation_path(consultation)
+
+        expect(nth_row(1).find(".response-title")).to have_content("A")
+        expect(nth_row(1).find(".membership-type")).to have_content("consumer")
+        expect(nth_row(1).find(".membership-weight")).to have_content(3)
+        expect(nth_row(1).find(".votes-count")).to have_content(1)
+
+        expect(nth_row(2).find(".response-title")).to have_content("A")
+        expect(nth_row(2).find(".membership-type")).to have_content("consumer")
+        expect(nth_row(2).find(".membership-weight")).to have_content(1)
+        expect(nth_row(2).find(".votes-count")).to have_content(1)
+
+        expect(nth_row(3).find(".response-title")).to have_content("A")
+        expect(nth_row(3).find(".membership-type")).to have_content("producer")
+        expect(nth_row(3).find(".membership-weight")).to have_content(2)
+        expect(nth_row(3).find(".votes-count")).to have_content(1)
+
+        expect(nth_row(4).find(".response-title")).to have_content("A")
+        expect(nth_row(4).find(".membership-type")).to have_content("")
+        expect(nth_row(4).find(".membership-weight")).to have_content("")
+        expect(nth_row(4).find(".votes-count")).to have_content(1)
+
+        expect(nth_row(5).find(".response-title")).to have_content("B")
+        expect(nth_row(5).find(".membership-type")).to have_content("consumer")
+        expect(nth_row(5).find(".membership-weight")).to have_content(1)
+        expect(nth_row(5).find(".votes-count")).to have_content(1)
+      end
+    end
+
     it "enables exporting to CSV" do
       visit decidim_admin_action_delegator.results_consultation_path(consultation)
       perform_enqueued_jobs { click_link(I18n.t("decidim.admin.consultations.results.export")) }

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -83,36 +83,6 @@ describe "Admin manages consultation results", type: :system do
       expect(nth_row(4).find(".votes-count")).to have_content(1)
     end
 
-    context "when an author has multiple authorizations" do
-      before do
-        create(:authorization, user: user, metadata: {})
-      end
-
-      it "shows an odd row" do
-        visit decidim_admin_action_delegator.results_consultation_path(consultation)
-
-        expect(nth_row(1).find(".response-title")).to have_content("A")
-        expect(nth_row(1).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(1).find(".membership-weight")).to have_content(3)
-        expect(nth_row(1).find(".votes-count")).to have_content(1)
-
-        expect(nth_row(2).find(".response-title")).to have_content("A")
-        expect(nth_row(2).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(2).find(".membership-weight")).to have_content(1)
-        expect(nth_row(2).find(".votes-count")).to have_content(1)
-
-        expect(nth_row(3).find(".response-title")).to have_content("A")
-        expect(nth_row(3).find(".membership-type")).to have_content("producer")
-        expect(nth_row(3).find(".membership-weight")).to have_content(2)
-        expect(nth_row(3).find(".votes-count")).to have_content(1)
-
-        expect(nth_row(4).find(".response-title")).to have_content("B")
-        expect(nth_row(4).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(4).find(".membership-weight")).to have_content(1)
-        expect(nth_row(4).find(".votes-count")).to have_content(1)
-      end
-    end
-
     it "enables exporting to CSV" do
       visit decidim_admin_action_delegator.results_consultation_path(consultation)
       perform_enqueued_jobs { click_link(I18n.t("decidim.admin.consultations.results.export")) }

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -24,11 +24,11 @@ describe "Admin manages consultation results", type: :system do
     question.votes.create(author: another_user, response: response)
     question.votes.create(author: yet_another_user, response: other_response)
 
-    create(:authorization, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
-    create(:authorization, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
-    create(:authorization, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+    create(:authorization, :direct_verification, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
+    create(:authorization, :direct_verification, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
+    create(:authorization, :direct_verification, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
 
-    create(:authorization, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+    create(:authorization, :direct_verification, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
 
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -106,15 +106,10 @@ describe "Admin manages consultation results", type: :system do
         expect(nth_row(3).find(".membership-weight")).to have_content(2)
         expect(nth_row(3).find(".votes-count")).to have_content(1)
 
-        expect(nth_row(4).find(".response-title")).to have_content("A")
-        expect(nth_row(4).find(".membership-type")).to have_content("")
-        expect(nth_row(4).find(".membership-weight")).to have_content("")
+        expect(nth_row(4).find(".response-title")).to have_content("B")
+        expect(nth_row(4).find(".membership-type")).to have_content("consumer")
+        expect(nth_row(4).find(".membership-weight")).to have_content(1)
         expect(nth_row(4).find(".votes-count")).to have_content(1)
-
-        expect(nth_row(5).find(".response-title")).to have_content("B")
-        expect(nth_row(5).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(5).find(".membership-weight")).to have_content(1)
-        expect(nth_row(5).find(".votes-count")).to have_content(1)
       end
     end
 


### PR DESCRIPTION
This results in more votes than really exist and messes up results. Due to this, total votes in frontoffice and backoffice don't match.

Note that having multiple authorizations records for the same user and name can't happen because of the following `Decidim::Authorization`'s validation in `decidim-core`:

```ruby
validates :name, uniqueness: { scope: :decidim_user_id }