### PR TITLE
Include unauthorized votes

### DIFF
--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -21,44 +21,54 @@ module Decidim
       def query
         relation
           .joins(:votes)
-          .joins(decidim_authorizations)
-          .group(
-            responses[:decidim_consultations_questions_id],
-            responses[:title],
-            metadata_field(:membership_type),
-            metadata_field(:membership_weight)
-          )
+          .joins(authorizations_on_author)
           .select(
             responses[:decidim_consultations_questions_id],
             responses[:title],
-            metadata_field_with_alias(:membership_type),
-            metadata_field_with_alias(:membership_weight),
-            "COUNT(*) AS votes_count"
+            membership(:type),
+            membership(:weight),
+            count_star.as(sql(:votes_count))
           )
           .where(direct_verification.or(no_authorization))
-          .order(:title, :membership_type, membership_weight: :desc)
-          .order("votes_count DESC")
+          .group(
+            responses[:decidim_consultations_questions_id],
+            responses[:title],
+            metadata(:membership_type),
+            metadata(:membership_weight)
+          )
+          .order(:title, :membership_type, { membership_weight: :desc }, votes_count)
       end
 
       private
 
       attr_reader :relation
 
-      def decidim_authorizations
-        <<-SQL.strip_heredoc
-          LEFT JOIN decidim_authorizations
-          ON decidim_authorizations.decidim_user_id = decidim_consultations_votes.decidim_author_id
-        SQL
+      def membership(field)
+        full_field = "membership_#{field}"
+        coalesce(metadata(full_field), default_metadata).as(full_field)
+      end
+
+      def default_metadata
+        Arel.sql("'#{DEFAULT_METADATA}'")
+      end
+
+      def authorizations_on_author
+        join_on = votes.create_on(authorizations[:decidim_user_id].eq(votes[:decidim_author_id]))
+        authorizations.create_join(authorizations, join_on, Arel::Nodes::OuterJoin)
+      end
+
+      def votes_count
+        "votes_count DESC"
+      end
+
+      def count_star
+        sql("COUNT(*)")
       end
 
       # Retuns the value of the specified key in the `metadata` JSONB PostgreSQL column. More
       # details: https://www.postgresql.org/docs/current/functions-json.html
-      def metadata_field(name)
-        "decidim_authorizations.metadata ->> '#{name}'"
-      end
-
-      def metadata_field_with_alias(name)
-        "COALESCE(#{metadata_field(name)}, '#{DEFAULT_METADATA}') AS #{name}"
+      def metadata(name)
+        Arel::Nodes::InfixOperation.new("->>", authorizations[:metadata], sql("'#{name}'"))
       end
 
       def direct_verification
@@ -75,6 +85,24 @@ module Decidim
 
       def responses
         Decidim::Consultations::Response.arel_table
+      end
+
+      def votes
+        Decidim::Consultations::Vote.arel_table
+      end
+
+      def sql(name)
+        Arel.sql(name.to_s)
+      end
+
+      def as(left, right)
+        Arel::Nodes::As.new(left, right)
+      end
+
+      # This method comes with Rails 6. See:
+      # https://github.com/rails/rails/commit/e5190acacd1088211cfe6f128b782af216aa6570
+      def coalesce(*exprs)
+        Arel::Nodes::NamedFunction.new("COALESCE", exprs)
       end
     end
   end

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -12,7 +12,7 @@ module Decidim
     # Note that although we assume `membership_type` to be a string and `membership_weight` to be an
     # integer, there are no implications in the code for their actual data types.
     class ResponsesByMembership < Rectify::Query
-      DEFAULT_METADATA = "(membership data not available)"
+      DEFAULT_METADATA = I18n.t("decidim.admin.consultations.results.default_metadata")
 
       def initialize(relation = nil)
         @relation = relation.presence || Decidim::Consultations::Response

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
     admin:
       consultations:
         results:
+          default_metadata: "(membership data not available)"
           export: Export
           export_filename: consultation_results
           membership_type: Membership type

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -92,5 +92,26 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
         expect(result.third).to be_nil
       end
     end
+
+    context "when usesrs don't have authorization" do
+      let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+      let(:other_auth_metadata) { { membership_type: "consumer", membership_weight: 2 } }
+
+      before do
+        Decidim::Authorization.where(user: other_user).destroy_all
+      end
+
+      it "includes their vote but highlights the lack of membership data" do
+        result = subject.query
+
+        expect(result.first.membership_type).to eq("(membership data not available)")
+        expect(result.first.membership_weight).to eq("(membership data not available)")
+        expect(result.first.votes_count).to eq(1)
+
+        expect(result.second.membership_type).to eq("producer")
+        expect(result.second.membership_weight).to eq("2")
+        expect(result.second.votes_count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Total votes in frontoffice and backoffice must match. Users inevitably think there's a bug otherwise. This way we make it a bit more clear that there's no membership data we can use to group the results.

Now, when there's a matching authorization we'll show it like:

![Screenshot from 2020-10-30 17-12-17](https://user-images.githubusercontent.com/762088/97729741-4a2fcb80-1ad3-11eb-8b63-ce1cd6806e28.png)

That's slightly better than having total votes not match.
