### PR TITLE
New sum of weights results

### DIFF
--- a/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
@@ -33,7 +33,8 @@ module Decidim
         end
 
         def responses_by_membership
-          ResponsesByMembership.new(published_questions_responses).query
+          relation = VotedResponses.new(published_questions_responses).query
+          ResponsesByMembership.new(relation).query
         end
 
         def published_questions_responses

--- a/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
@@ -4,12 +4,11 @@ module Decidim
   module ActionDelegator
     module Admin
       class ConsultationsController < Decidim::Consultations::Admin::ConsultationsController
-        helper_method :responses_for
-
         def results
           enforce_permission_to :read, :consultation, consultation: current_consultation
 
           @questions = questions
+          @responses = responses.group_by(&:decidim_consultations_questions_id)
 
           render layout: "decidim/admin/consultation"
         end
@@ -24,21 +23,12 @@ module Decidim
           current_consultation.questions.published.includes(:responses)
         end
 
-        def responses_for(question)
-          responses.fetch(question.id, [])
-        end
-
         def responses
-          @responses ||= responses_by_membership.group_by(&:decidim_consultations_questions_id)
-        end
-
-        def responses_by_membership
-          relation = VotedResponses.new(published_questions_responses).query
-          ResponsesByMembership.new(relation).query
+          ResponsesByMembership.new(published_questions_responses).query
         end
 
         def published_questions_responses
-          PublishedResponses.new(current_consultation).query
+          VotedResponses.new(PublishedResponses.new(current_consultation).query).query
         end
       end
     end

--- a/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
@@ -28,7 +28,7 @@ module Decidim
         end
 
         def published_questions_responses
-          VotedResponses.new(PublishedResponses.new(current_consultation).query).query
+          VotedWithDirectVerification.new(PublishedResponses.new(current_consultation).query).query
         end
       end
     end

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   module ActionDelegator
     module Admin
@@ -29,7 +31,7 @@ module Decidim
           end
 
           def responses_by_membership
-            ResponsesByMembership.new(published_questions_responses).query
+            SumOfMembershipWeight.new(published_questions_responses).query
           end
 
           def published_questions_responses

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -18,6 +18,10 @@ module Decidim
 
           private
 
+          def permission_class_chain
+            Decidim.permissions_registry.chain_for(ActionDelegator::Admin::ApplicationController)
+          end
+
           def questions
             current_consultation.questions.published.includes(:responses)
           end

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -1,0 +1,42 @@
+module Decidim
+  module ActionDelegator
+    module Admin
+      module Results
+        class SumOfWeightsController < Decidim::Consultations::Admin::ConsultationsController
+          helper_method :responses_for
+
+          def index
+            params[:slug] = params[:consultation_slug]
+
+            enforce_permission_to :read, :consultation, consultation: current_consultation
+            @questions = questions
+
+            render layout: "decidim/admin/consultation"
+          end
+
+          private
+
+          def questions
+            current_consultation.questions.published.includes(:responses)
+          end
+
+          def responses_for(question)
+            responses.fetch(question.id, [])
+          end
+
+          def responses
+            @responses ||= responses_by_membership.group_by(&:decidim_consultations_questions_id)
+          end
+
+          def responses_by_membership
+            ResponsesByMembership.new(published_questions_responses).query
+          end
+
+          def published_questions_responses
+            PublishedResponses.new(current_consultation).query
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -31,7 +31,7 @@ module Decidim
           end
 
           def published_questions_responses
-            VotedResponses.new(PublishedResponses.new(current_consultation).query).query
+            VotedWithDirectVerification.new(PublishedResponses.new(current_consultation).query).query
           end
         end
       end

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -31,7 +31,8 @@ module Decidim
           end
 
           def responses_by_membership
-            SumOfMembershipWeight.new(published_questions_responses).query
+            relation = VotedResponses.new(published_questions_responses).query
+            SumOfMembershipWeight.new(relation).query
           end
 
           def published_questions_responses

--- a/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
+++ b/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
@@ -17,7 +17,7 @@ module Decidim
       attr_reader :consultation
 
       def collection
-        relation = VotedResponses.new(published_questions_responses).query
+        relation = VotedWithDirectVerification.new(published_questions_responses).query
         ResponsesByMembership.new(relation).query
       end
 

--- a/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
+++ b/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
@@ -17,7 +17,8 @@ module Decidim
       attr_reader :consultation
 
       def collection
-        ResponsesByMembership.new.query.merge(published_questions_responses)
+        relation = VotedResponses.new(published_questions_responses).query
+        ResponsesByMembership.new(relation).query
       end
 
       # Returns the published questions' responses of the given consultation as an ActiveRecord

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -27,7 +27,7 @@ module Decidim
             responses[:title],
             membership(:type),
             membership(:weight),
-            count_star.as(sql(:votes_count))
+            votes_count
           )
           .where(direct_verification.or(no_authorization))
           .group(
@@ -36,7 +36,7 @@ module Decidim
             metadata(:membership_type),
             metadata(:membership_weight)
           )
-          .order(:title, :membership_type, { membership_weight: :desc }, votes_count)
+          .order(:title, :membership_type, { membership_weight: :desc }, "votes_count DESC")
       end
 
       private
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def votes_count
-        "votes_count DESC"
+        count_star.as(sql(:votes_count))
       end
 
       def count_star

--- a/app/queries/decidim/action_delegator/responses_by_membership.rb
+++ b/app/queries/decidim/action_delegator/responses_by_membership.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json_key"
+
 module Decidim
   module ActionDelegator
     # Returns total votes of each response by memberships' type and weight.
@@ -53,10 +55,8 @@ module Decidim
         sql("COUNT(*)").as(sql(:votes_count))
       end
 
-      # Retuns the value of the specified key in the `metadata` JSONB PostgreSQL column. More
-      # details: https://www.postgresql.org/docs/current/functions-json.html
       def metadata(name)
-        Arel::Nodes::InfixOperation.new("->>", authorizations[:metadata], sql("'#{name}'"))
+        JSONKey.new(authorizations[:metadata], name)
       end
 
       def authorizations

--- a/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
+++ b/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
@@ -75,7 +75,7 @@ module Decidim
 
       def membership_weight
         field = metadata("membership_weight")
-        "(#{field.to_sql})::INTEGER"
+        "CAST((#{field.to_sql}) AS INTEGER)"
       end
 
       def metadata(name)

--- a/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
+++ b/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class SumOfMembershipWeight < Rectify::Query
+      DEFAULT_METADATA = I18n.t("decidim.admin.consultations.results.default_metadata")
+
+      def initialize(relation = nil)
+        @relation = relation.presence || Decidim::Consultations::Response
+      end
+
+      def query
+        relation
+          .joins(:votes)
+          .joins(authorizations_on_author)
+          .select(
+            responses[:decidim_consultations_questions_id],
+            responses[:title],
+            votes_count
+          )
+          .where(direct_verification.or(no_authorization))
+          .group(
+            responses[:decidim_consultations_questions_id],
+            responses[:title]
+          )
+          .order(:title)
+      end
+
+      private
+
+      attr_reader :relation
+
+      def authorizations_on_author
+        join_on = votes.create_on(authorizations[:decidim_user_id].eq(votes[:decidim_author_id]))
+        authorizations.create_join(authorizations, join_on, Arel::Nodes::OuterJoin)
+      end
+
+      def votes
+        Decidim::Consultations::Vote.arel_table
+      end
+
+      def authorizations
+        Decidim::Authorization.arel_table
+      end
+
+      def responses
+        Decidim::Consultations::Response.arel_table
+      end
+
+      def sql(name)
+        Arel.sql(name.to_s)
+      end
+
+      def default_metadata
+        Arel.sql("'#{DEFAULT_METADATA}'")
+      end
+
+      def count_star
+        sql("COUNT(*)")
+      end
+
+      def direct_verification
+        authorizations[:name].eq("direct_verifications")
+      end
+
+      def no_authorization
+        authorizations[:id].eq(nil)
+      end
+
+      def votes_count
+        # "4 AS votes_count"
+        # coalesce(membership_weight, 1).as(sql(:votes_count))
+        "SUM(COALESCE(#{membership_weight}, 1)) AS votes_count"
+      end
+
+      def membership_weight
+        field = metadata("membership_weight")
+        "(#{field.to_sql})::INTEGER"
+      end
+
+      def metadata(name)
+        Arel::Nodes::InfixOperation.new("->>", authorizations[:metadata], sql("'#{name}'"))
+      end
+
+      def coalesce(*exprs)
+        Arel::Nodes::NamedFunction.new("COALESCE", exprs)
+      end
+
+      def cast(expr, type)
+        Arel::Nodes::NamedFunction.new("CAST", "#{expr.to_sql} AS #{type.upcase}")
+      end
+
+      def as(left, right)
+        Arel::Nodes::As.new(left, right)
+      end
+    end
+  end
+end

--- a/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
+++ b/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
@@ -3,22 +3,17 @@
 module Decidim
   module ActionDelegator
     class SumOfMembershipWeight < Rectify::Query
-      DEFAULT_METADATA = I18n.t("decidim.admin.consultations.results.default_metadata")
-
-      def initialize(relation = nil)
-        @relation = relation.presence || Decidim::Consultations::Response
+      def initialize(relation)
+        @relation = relation
       end
 
       def query
         relation
-          .joins(:votes)
-          .joins(authorizations_on_author)
           .select(
             responses[:decidim_consultations_questions_id],
             responses[:title],
             votes_count
           )
-          .where(direct_verification.or(no_authorization))
           .group(
             responses[:decidim_consultations_questions_id],
             responses[:title]
@@ -30,41 +25,12 @@ module Decidim
 
       attr_reader :relation
 
-      def authorizations_on_author
-        join_on = votes.create_on(authorizations[:decidim_user_id].eq(votes[:decidim_author_id]))
-        authorizations.create_join(authorizations, join_on, Arel::Nodes::OuterJoin)
-      end
-
-      def votes
-        Decidim::Consultations::Vote.arel_table
-      end
-
-      def authorizations
-        Decidim::Authorization.arel_table
-      end
-
       def responses
         Decidim::Consultations::Response.arel_table
       end
 
       def sql(name)
         Arel.sql(name.to_s)
-      end
-
-      def default_metadata
-        Arel.sql("'#{DEFAULT_METADATA}'")
-      end
-
-      def count_star
-        sql("COUNT(*)")
-      end
-
-      def direct_verification
-        authorizations[:name].eq("direct_verifications")
-      end
-
-      def no_authorization
-        authorizations[:id].eq(nil)
       end
 
       def votes_count
@@ -82,12 +48,16 @@ module Decidim
         Arel::Nodes::InfixOperation.new("->>", authorizations[:metadata], sql("'#{name}'"))
       end
 
+      def authorizations
+        Decidim::Authorization.arel_table
+      end
+
       def coalesce(*exprs)
         Arel::Nodes::NamedFunction.new("COALESCE", exprs)
       end
 
-      def cast(expr, type)
-        Arel::Nodes::NamedFunction.new("CAST", "#{expr.to_sql} AS #{type.upcase}")
+      def cast(*exprs)
+        Arel::Nodes::UnaryOperation.new("::INTEGER", responses[:id]).to_sql
       end
 
       def as(left, right)

--- a/app/queries/decidim/action_delegator/voted_responses.rb
+++ b/app/queries/decidim/action_delegator/voted_responses.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class VotedResponses < Rectify::Query
+      def initialize(relation)
+        @relation = relation
+      end
+
+      def query
+        relation
+          .joins(:votes)
+          .joins(authorizations_on_author)
+          .where(direct_verification.or(no_authorization))
+      end
+
+      private
+
+      attr_reader :relation
+
+      def authorizations_on_author
+        join_on = votes.create_on(authorizations[:decidim_user_id].eq(votes[:decidim_author_id]))
+        authorizations.create_join(authorizations, join_on, Arel::Nodes::OuterJoin)
+      end
+
+      def votes
+        Decidim::Consultations::Vote.arel_table
+      end
+
+      def authorizations
+        Decidim::Authorization.arel_table
+      end
+
+      def direct_verification
+        authorizations[:name].eq("direct_verifications")
+      end
+
+      def no_authorization
+        authorizations[:id].eq(nil)
+      end
+    end
+  end
+end

--- a/app/queries/decidim/action_delegator/voted_with_direct_verification.rb
+++ b/app/queries/decidim/action_delegator/voted_with_direct_verification.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module ActionDelegator
-    class VotedResponses < Rectify::Query
+    class VotedWithDirectVerification < Rectify::Query
       def initialize(relation)
         @relation = relation
       end

--- a/app/queries/decidim/action_delegator/votes_count_aggregation.rb
+++ b/app/queries/decidim/action_delegator/votes_count_aggregation.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class VotesCountAggregation
+      def initialize(field, aliaz)
+        @field = field
+        @aliaz = aliaz
+      end
+
+      def to_sql
+        int_field = cast(field, :integer)
+        int_field = coalesce(int_field, 1)
+        Arel::Nodes::Sum.new([int_field], aliaz).to_sql
+      end
+
+      private
+
+      attr_reader :field, :aliaz
+
+      # Returns the equivalent of `CAST ((<exprs>) AS <type>)` in Arel
+      def cast(*exprs, type)
+        Arel::Nodes::NamedFunction.new(
+          "CAST",
+          [Arel::Nodes::As.new(Arel::Nodes::Grouping.new(exprs), Arel.sql(type.to_s.upcase))]
+        )
+      end
+
+      def coalesce(*exprs)
+        Arel::Nodes::NamedFunction.new("COALESCE", exprs)
+      end
+    end
+  end
+end

--- a/app/views/decidim/action_delegator/admin/consultations/results.html.erb
+++ b/app/views/decidim/action_delegator/admin/consultations/results.html.erb
@@ -38,7 +38,7 @@
           </thead>
           <tbody>
             <% if question.publishable_results? %>
-              <% responses_for(question).each do |row| %>
+              <% @responses.fetch(question.id, []).each do |row| %>
               <tr>
                 <td class="response-title"><%= strip_tags translated_attribute row.title %></td>
                 <td class="membership-type"><%= row.membership_type %></td>

--- a/app/views/decidim/action_delegator/admin/consultations/results.html.erb
+++ b/app/views/decidim/action_delegator/admin/consultations/results.html.erb
@@ -1,7 +1,7 @@
 <div class="card" id="consultations">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t "decidim.admin.titles.results" %>
+      <%= t ".title" %>
       <span class="label button--title">
         <%= t "decidim.admin.consultations.results.total_votes", count: current_consultation.total_votes %>
         /

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -36,7 +36,7 @@
           </thead>
           <tbody>
             <% if question.publishable_results? %>
-              <% responses_for(question).each do |row| %>
+              <% @responses.fetch(question.id, []).each do |row| %>
               <tr>
                 <td class="response-title"><%= strip_tags translated_attribute row.title %></td>
                 <td class="votes-count"><%= row.votes_count %></td>

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -1,0 +1,62 @@
+<div class="card" id="consultations">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t "decidim.admin.titles.results" %>
+      <span class="label button--title">
+        <%= t "decidim.admin.consultations.results.total_votes", count: current_consultation.total_votes %>
+        /
+        <%= t 'decidim.admin.consultations.results.total_delegates', count: Decidim::ActionDelegator::DelegatesVotesByConsultation.new(current_consultation).query %>
+        /
+        <%= t "decidim.admin.consultations.results.participants", count: current_consultation.total_participants %>
+      </span>
+      <span id="export-consultation-results" class="button--title">
+        <% if allowed_to?(:export_consultation_results, :consultation, consultation: current_consultation) %>
+          <%= link_to t("decidim.admin.consultations.results.export"), decidim_admin_action_delegator.consultation_exports_path(current_consultation), method: :post, class: "button tiny button--title" %>
+        <% else %>
+          <span class="button tiny button--title disabled"><%= t("decidim.admin.consultations.results.export") %></span>
+        <% end %>
+      </span>
+    </h2>
+  </div>
+  <div class="card-section">
+    <table class="table-list">
+      <% @questions.each do |question| %>
+        <% unless question.external_voting %>
+          <thead>
+            <tr>
+              <th><%= strip_tags translated_attribute question.title %></th>
+              <th><%= I18n.t("decidim.admin.consultations.results.membership_type") %></th>
+              <th><%= I18n.t("decidim.admin.consultations.results.membership_weight") %></th>
+              <th class="table-list__actions">
+                <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
+                /
+                <%= t 'decidim.admin.consultations.results.total_delegates', count: Decidim::ActionDelegator::DelegatesVotesByQuestion.new(question).query %>
+                /
+                <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if question.publishable_results? %>
+              <% responses_for(question).each do |row| %>
+              <tr>
+                <td class="response-title"><%= strip_tags translated_attribute row.title %></td>
+                <td class="membership-type"><%= row.membership_type %></td>
+                <td class="membership-weight"><%= row.membership_weight %></td>
+                <td class="votes-count"><%= row.votes_count %></td>
+              </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td><em><%= t "decidim.admin.consultations.results.not_visible" %></em></td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+              </tr>
+            <% end %>
+          </tbody>
+        <% end %>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -19,14 +19,12 @@
     </h2>
   </div>
   <div class="card-section">
-    <table class="table-list">
+    <table id="results" class="table-list">
       <% @questions.each do |question| %>
         <% unless question.external_voting %>
           <thead>
             <tr>
               <th><%= strip_tags translated_attribute question.title %></th>
-              <th><%= I18n.t("decidim.admin.consultations.results.membership_type") %></th>
-              <th><%= I18n.t("decidim.admin.consultations.results.membership_weight") %></th>
               <th class="table-list__actions">
                 <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
                 /
@@ -41,8 +39,6 @@
               <% responses_for(question).each do |row| %>
               <tr>
                 <td class="response-title"><%= strip_tags translated_attribute row.title %></td>
-                <td class="membership-type"><%= row.membership_type %></td>
-                <td class="membership-weight"><%= row.membership_weight %></td>
                 <td class="votes-count"><%= row.votes_count %></td>
               </tr>
               <% end %>

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -1,7 +1,7 @@
 <div class="card" id="consultations">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t "decidim.admin.titles.results" %>
+      <%= t ".title" %>
       <span class="label button--title">
         <%= t "decidim.admin.consultations.results.total_votes", count: current_consultation.total_votes %>
         /

--- a/app/views/layouts/decidim/admin/consultation.html.erb
+++ b/app/views/layouts/decidim/admin/consultation.html.erb
@@ -17,14 +17,18 @@
         <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation), /\/results/) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
                                     decidim_admin_consultations.results_consultation_path(current_consultation) %>
-          <ul>
+          <ul class="results-nav">
             <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
               <%= aria_selected_link_to t("by_answer", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
                                         decidim_admin_consultations.results_consultation_path(current_consultation) %>
             </li>
-            <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
+            <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation), :exact) %> class="is-active" <% end %>>
               <%= aria_selected_link_to t("by_type_and_weight", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
                                         decidim_admin_action_delegator.results_consultation_path(current_consultation) %>
+            </li>
+            <li <% if is_active_link?(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation), :exact) %> class="is-active" <% end %>>
+              <%= aria_selected_link_to t("sum_of_weights", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
+                                        decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation) %>
             </li>
           </ul>
         </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
           consultations_submenu:
             by_answer: By answer
             by_type_and_weight: By type and weight
+            sum_of_weights: By sum of weights
           delegations: User delegations
           participants: Participants
         settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,9 @@ en:
   decidim:
     action_delegator:
       admin:
+        consultations:
+          results:
+            title: Results by answer, membership type and weight
         delegations:
           create:
             error: There was a problem creating the delegation
@@ -37,6 +40,10 @@ en:
             sum_of_weights: By sum of weights
           delegations: User delegations
           participants: Participants
+        results:
+          sum_of_weights:
+            index:
+              title: Results by answer summing membership weights
         settings:
           create:
             error: There was a problem creating the settings

--- a/lib/decidim/action_delegator/admin_engine.rb
+++ b/lib/decidim/action_delegator/admin_engine.rb
@@ -17,6 +17,10 @@ module Decidim
         resources :consultations, param: :slug, only: [] do
           get :results, on: :member
           resources :exports, only: [:create], module: :consultations
+
+          namespace :results do
+            resources :sum_of_weights, only: :index
+          end
         end
 
         root to: "delegations#index"

--- a/lib/json_key.rb
+++ b/lib/json_key.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Returns the PostgreSQL statement to get a JSON object field as text. Note this work for both
+# JSON and JSONB type columns. More details:
+# https://www.postgresql.org/docs/current/functions-json.html
+class JSONKey < Arel::Nodes::InfixOperation
+  def initialize(left, right)
+    super("->>", left, Arel::Nodes.build_quoted(right))
+  end
+end

--- a/spec/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ActionDelegator::Admin::Results::SumOfWeightsController, type: :controller do
+  routes { Decidim::ActionDelegator::AdminEngine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:consultation) { create(:consultation, organization: organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+    sign_in user
+  end
+
+  describe "#index" do
+    it "authorizes the action" do
+      expect(controller).to receive(:allowed_to?).with(:read, :consultation, anything)
+      get :index, params: { consultation_slug: consultation.slug }
+    end
+
+    it "renders decidim/admin/consultation layout" do
+      get :index, params: { consultation_slug: consultation.slug }
+      expect(response).to render_template("layouts/decidim/admin/consultation")
+    end
+  end
+end

--- a/spec/lib/json_key_spec.rb
+++ b/spec/lib/json_key_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json_key"
+
+describe JSONKey do
+  let(:node) { described_class.new(json_document, key) }
+
+  describe "#to_sql" do
+    let(:json_document) { Arel::Table.new("table")[:document] }
+    let(:key) { "key" }
+
+    it "returns PostgreSQL ->> statement to fetch key" do
+      expect(node.to_sql).to eq('"table"."document" ->> \'key\'')
+    end
+  end
+end

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -5,7 +5,10 @@ require "spec_helper"
 describe Decidim::ActionDelegator::ResponsesByMembership do
   subject { described_class.new(relation) }
 
-  let(:relation) { Decidim::Consultations::Response.where(question: question) }
+  let(:relation) do
+    relation = Decidim::Consultations::Response.where(question: question)
+    Decidim::ActionDelegator::VotedResponses.new(relation).query
+  end
 
   let(:organization) { create(:organization) }
   let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }

--- a/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
+++ b/spec/queries/decidim/action_delegator/responses_by_membership_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::ActionDelegator::ResponsesByMembership do
 
   let(:relation) do
     relation = Decidim::Consultations::Response.where(question: question)
-    Decidim::ActionDelegator::VotedResponses.new(relation).query
+    Decidim::ActionDelegator::VotedWithDirectVerification.new(relation).query
   end
 
   let(:organization) { create(:organization) }

--- a/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
+++ b/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe SumOfMembershipWeight do
+      subject(:query_object) { described_class.new(relation) }
+
+      let(:relation) do
+        relation = Decidim::Consultations::Response.where(question: question)
+        Decidim::ActionDelegator::VotedResponses.new(relation).query
+      end
+
+      let(:organization) { create(:organization) }
+      let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+      let(:question) { create(:question, consultation: consultation) }
+      let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+      let(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
+      let(:response) { create(:response, question: question) }
+
+      before do
+        question.votes.create(author: user, response: response)
+        question.votes.create(author: other_user, response: response)
+      end
+
+      describe "#query" do
+        context "when all users have membership" do
+          let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+          let(:other_auth_metadata) { { membership_type: "producer", membership_weight: 3 } }
+
+          before do
+            create(:authorization, :direct_verification, user: user, metadata: auth_metadata)
+            create(:authorization, :direct_verification, user: other_user, metadata: other_auth_metadata)
+          end
+
+          it "aggregates their membership weights" do
+            result_set = query_object.query
+
+            expect(result_set.first.votes_count)
+              .to eq(auth_metadata[:membership_weight] + other_auth_metadata[:membership_weight])
+          end
+        end
+
+        context "when some users have no membership" do
+          let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
+
+          before do
+            create(:authorization, :direct_verification, user: user, metadata: auth_metadata)
+          end
+
+          it "aggregates their vote as a single one" do
+            result_set = query_object.query
+
+            expect(result_set.first.votes_count).to eq(auth_metadata[:membership_weight] + 1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
+++ b/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:relation) do
         relation = Decidim::Consultations::Response.where(question: question)
-        Decidim::ActionDelegator::VotedResponses.new(relation).query
+        Decidim::ActionDelegator::VotedWithDirectVerification.new(relation).query
       end
 
       let(:organization) { create(:organization) }

--- a/spec/queries/decidim/action_delegator/voted_responses_spec.rb
+++ b/spec/queries/decidim/action_delegator/voted_responses_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe VotedResponses do
+      subject(:query_object) { described_class.new(relation) }
+
+      let(:relation) { Decidim::Consultations::Response.where(question: question) }
+
+      let(:organization) { create(:organization) }
+      let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+      let(:question) { create(:question, consultation: consultation) }
+      let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+      let(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
+      let(:response) { create(:response, question: question) }
+
+      before do
+        question.votes.create(author: user, response: response)
+        question.votes.create(author: other_user, response: response)
+      end
+
+      describe "#query" do
+        context "when an author is authorized" do
+          before do
+            create(:authorization, :direct_verification, user: user)
+            create(:authorization, name: "other_verifications", user: other_user)
+          end
+
+          it "includes only responses of those authorized with direct_verifications" do
+            expect(query_object.query).to eq([response])
+          end
+        end
+
+        context "when an author has no authorization" do
+          it "includes their responses" do
+            expect(query_object.query).to eq([response, response])
+          end
+        end
+
+        context "when mixing authors with and without direct_verification" do
+          before do
+            create(:authorization, :direct_verification, user: user)
+          end
+
+          it "includes their responses" do
+            expect(query_object.query).to eq([response, response])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/decidim/action_delegator/voted_with_direct_verification_spec.rb
+++ b/spec/queries/decidim/action_delegator/voted_with_direct_verification_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim
   module ActionDelegator
-    describe VotedResponses do
+    describe VotedWithDirectVerification do
       subject(:query_object) { described_class.new(relation) }
 
       let(:relation) { Decidim::Consultations::Response.where(question: question) }

--- a/spec/queries/decidim/action_delegator/votes_count_aggregation_spec.rb
+++ b/spec/queries/decidim/action_delegator/votes_count_aggregation_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe VotesCountAggregation do
+      subject(:aggregation) { described_class.new(Arel.sql("foo"), "alias") }
+
+      describe "#to_sql" do
+        it "returns the SUM of the specified field" do
+          expect(aggregation.to_sql).to eq("SUM(COALESCE(CAST((foo) AS INTEGER), 1)) AS alias")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -24,11 +24,30 @@ describe "Admin manages consultation results", type: :system do
     question.votes.create(author: another_user, response: response)
     question.votes.create(author: yet_another_user, response: other_response)
 
-    create(:authorization, :direct_verification, user: user, metadata: { membership_type: "producer", membership_weight: 2 })
-    create(:authorization, :direct_verification, user: other_user, metadata: { membership_type: "consumer", membership_weight: 3 })
-    create(:authorization, :direct_verification, user: another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
-
-    create(:authorization, :direct_verification, user: yet_another_user, metadata: { membership_type: "consumer", membership_weight: 1 })
+    create(
+      :authorization,
+      :direct_verification,
+      user: user,
+      metadata: { membership_type: "producer", membership_weight: 2 }
+    )
+    create(
+      :authorization,
+      :direct_verification,
+      user: other_user,
+      metadata: { membership_type: "consumer", membership_weight: 3 }
+    )
+    create(
+      :authorization,
+      :direct_verification,
+      user: another_user,
+      metadata: { membership_type: "consumer", membership_weight: 1 }
+    )
+    create(
+      :authorization,
+      :direct_verification,
+      user: yet_another_user,
+      metadata: { membership_type: "consumer", membership_weight: 1 }
+    )
 
     switch_to_host(organization.host)
     login_as user, scope: :user

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -56,6 +56,16 @@ describe "Admin manages consultation results", type: :system do
 
       expect(page).to have_current_path(decidim_admin_consultations.results_consultation_path(consultation))
     end
+
+    it "enables navigating to the sum of weights" do
+      click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.sum_of_weights")
+
+      within ".results-nav" do
+        expect(find(".is-active")).to have_link(href: decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+      end
+
+      expect(page).to have_current_path(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+    end
   end
 
   context "when in question page" do

--- a/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages sum of weight consultation results", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let!(:question) { create(:question, consultation: consultation) }
+  let!(:response) { create(:response, question: question, title: { "ca" => "A" }) }
+
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    # Regular vote
+    question.votes.create(author: user, response: response)
+    # Vote of a user with membership
+    question.votes.create(author: other_user, response: response)
+
+    create(
+      :authorization,
+      :direct_verification,
+      user: other_user,
+      metadata: { membership_type: "consumer", membership_weight: 3 }
+    )
+
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when viewing a finished consultation with votes" do
+    let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+
+    it "shows total votes taking membership weight into account" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+
+      # expect(page).to have_content("Total votes by answer considering weights")
+      within_table("results") do
+        expect(find(".response-title")).to have_content("A")
+        expect(find(".votes-count")).to have_content(4)
+      end
+    end
+
+    it "enables exporting to CSV" do
+    end
+  end
+
+  context "when viewing an unfinished consultation" do
+    let!(:consultation) { create(:consultation, :active, :unpublished_results, organization: organization) }
+
+    it "disables the export button" do
+    end
+
+    it "does not show any response" do
+    end
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
@@ -41,6 +41,13 @@ describe "Admin manages sum of weight consultation results", type: :system do
     end
 
     it "enables exporting to CSV" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+      perform_enqueued_jobs { click_link(I18n.t("decidim.admin.consultations.results.export")) }
+
+      expect(page).to have_content(I18n.t("decidim.admin.exports.notice"))
+
+      expect(last_email.subject).to include("results", "csv")
+      expect(last_email.attachments.first.filename).to match(/^consultation_results.*\.zip$/)
     end
   end
 
@@ -48,9 +55,17 @@ describe "Admin manages sum of weight consultation results", type: :system do
     let!(:consultation) { create(:consultation, :active, :unpublished_results, organization: organization) }
 
     it "disables the export button" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+
+      within "#export-consultation-results" do
+        expect(page).to have_css(".disabled")
+        expect(page).not_to have_link(I18n.t("decidim.admin.consultations.results.export"))
+      end
     end
 
     it "does not show any response" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+      expect(page).not_to have_content(find(:xpath, ".//table/tbody/tr[1]"))
     end
   end
 end

--- a/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
@@ -34,7 +34,6 @@ describe "Admin manages sum of weight consultation results", type: :system do
     it "shows total votes taking membership weight into account" do
       visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
 
-      # expect(page).to have_content("Total votes by answer considering weights")
       within_table("results") do
         expect(find(".response-title")).to have_content("A")
         expect(find(".votes-count")).to have_content(4)


### PR DESCRIPTION
Closes #86 . Adds a new page to list consultation votes adding the weights of each vote author. No membership data is displayed.

![Screenshot from 2021-03-18 17-21-46](https://user-images.githubusercontent.com/762088/111661373-43e68580-880f-11eb-8ff1-7f9e59fdb7e5.png)

![Screenshot from 2021-03-18 18-03-24](https://user-images.githubusercontent.com/762088/111666811-5dd69700-8814-11eb-86f3-49cb0fb0d319.png)
![Screenshot from 2021-03-18 18-03-15](https://user-images.githubusercontent.com/762088/111666829-60d18780-8814-11eb-955d-f0701fcbbe3a.png)

## TO DO

- [x] Check if it's possible to change the page header of each results table
- [ ] Show consultation's menu item as active in all results pages