### PR TITLE
Change MAX_DECIDIM_VERSION for upgrades instances

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     decidim-action_delegator (0.2)
-      decidim-admin (>= 0.22, <= 0.23.2)
-      decidim-consultations (>= 0.22, <= 0.23.2)
-      decidim-core (>= 0.22, <= 0.23.2)
+      decidim-admin (>= 0.22, < 0.24)
+      decidim-consultations (>= 0.22, < 0.24)
+      decidim-core (>= 0.22, < 0.24)
       savon
       twilio-ruby
 
@@ -814,10 +814,10 @@ DEPENDENCIES
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   codecov
-  decidim (<= 0.23.2)
+  decidim (< 0.24)
   decidim-action_delegator!
-  decidim-consultations (<= 0.23.2)
-  decidim-dev (<= 0.23.2)
+  decidim-consultations (< 0.24)
+  decidim-dev (< 0.24)
   faker (~> 1.9)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)

--- a/lib/decidim/action_delegator/version.rb
+++ b/lib/decidim/action_delegator/version.rb
@@ -4,7 +4,7 @@ module Decidim
   # This holds the decidim-action_delegator version.
   module ActionDelegator
     MIN_DECIDIM_VERSION = ">= 0.22"
-    MAX_DECIDIM_VERSION = "<= 0.23.2"
+    MAX_DECIDIM_VERSION = "< 0.24"
     VERSION = "0.2"
   end
 end


### PR DESCRIPTION
This change is proposed to be able to make upgrades to 0.23.

In instances where this dependency exists it doesn't work, because the release 0.23 has version 0.23.4.