### PR TITLE
Hide new results pages feature under feature flag

### DIFF
--- a/app/views/layouts/decidim/admin/consultation.html.erb
+++ b/app/views/layouts/decidim/admin/consultation.html.erb
@@ -14,24 +14,33 @@
           <%= aria_selected_link_to t("questions", scope: "decidim.admin.menu.consultations_submenu"),
                                     decidim_admin_consultations.consultation_questions_path(current_consultation) %>
         </li>
-        <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation), /\/results/) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
-                                    decidim_admin_consultations.results_consultation_path(current_consultation) %>
-          <ul class="results-nav">
-            <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
-              <%= aria_selected_link_to t("by_answer", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
-                                        decidim_admin_consultations.results_consultation_path(current_consultation) %>
-            </li>
-            <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation), :exact) %> class="is-active" <% end %>>
-              <%= aria_selected_link_to t("by_type_and_weight", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
-                                        decidim_admin_action_delegator.results_consultation_path(current_consultation) %>
-            </li>
-            <li <% if is_active_link?(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation), :exact) %> class="is-active" <% end %>>
-              <%= aria_selected_link_to t("sum_of_weights", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
-                                        decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation) %>
-            </li>
-          </ul>
-        </li>
+
+        <% if ENV["RESULTS_NAV"] %>
+          <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation), /\/results/) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
+                                      decidim_admin_consultations.results_consultation_path(current_consultation) %>
+            <ul class="results-nav">
+              <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("by_answer", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
+                                          decidim_admin_consultations.results_consultation_path(current_consultation) %>
+              </li>
+              <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation), :exact) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("by_type_and_weight", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
+                                          decidim_admin_action_delegator.results_consultation_path(current_consultation) %>
+              </li>
+              <li <% if is_active_link?(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation), :exact) %> class="is-active" <% end %>>
+                <%= aria_selected_link_to t("sum_of_weights", scope: "decidim.action_delegator.admin.menu.consultations_submenu"),
+                                          decidim_admin_action_delegator.consultation_results_sum_of_weights_path(current_consultation) %>
+              </li>
+            </ul>
+          </li>
+        <% else %>
+          <li <% if is_active_link?(decidim_admin_action_delegator.results_consultation_path(current_consultation)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
+                                      decidim_admin_action_delegator.results_consultation_path(current_consultation) %>
+          </li>
+        <% end %>
+
       <% end %>
     </ul>
   </div>

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -58,32 +58,47 @@ describe "Admin manages consultation results", type: :system do
 
     before { visit decidim_admin_consultations.edit_consultation_path(consultation) }
 
-    it "enables navigating to the default results page" do
-      click_link I18n.t("decidim.admin.menu.consultations_submenu.results")
-
-      expect(page).to have_current_path(decidim_admin_consultations.results_consultation_path(consultation))
-    end
-
-    it "enables navigating to the by membership type and weight results page" do
-      click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.by_type_and_weight")
-
-      expect(page).to have_current_path(decidim_admin_action_delegator.results_consultation_path(consultation))
-    end
-
-    it "enables navigating to the default results from the submenu link" do
-      click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.by_answer")
-
-      expect(page).to have_current_path(decidim_admin_consultations.results_consultation_path(consultation))
-    end
-
-    it "enables navigating to the sum of weights" do
-      click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.sum_of_weights")
-
-      within ".results-nav" do
-        expect(find(".is-active")).to have_link(href: decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+    context "when RESULTS_NAV is on" do
+      around do |example|
+        ENV["RESULTS_NAV"] = "1"
+        example.run
+        ENV["RESULTS_NAV"] = nil
       end
 
-      expect(page).to have_current_path(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+      it "enables navigating to the default results page" do
+        click_link I18n.t("decidim.admin.menu.consultations_submenu.results")
+
+        expect(page).to have_current_path(decidim_admin_consultations.results_consultation_path(consultation))
+      end
+
+      it "enables navigating to the by membership type and weight results page" do
+        click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.by_type_and_weight")
+
+        expect(page).to have_current_path(decidim_admin_action_delegator.results_consultation_path(consultation))
+      end
+
+      it "enables navigating to the default results from the submenu link" do
+        click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.by_answer")
+
+        expect(page).to have_current_path(decidim_admin_consultations.results_consultation_path(consultation))
+      end
+
+      it "enables navigating to the sum of weights" do
+        click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.sum_of_weights")
+
+        within ".results-nav" do
+          expect(find(".is-active")).to have_link(href: decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+        end
+
+        expect(page).to have_current_path(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
+      end
+    end
+
+    context "when RESULTS_NAV is off" do
+      it "enables navigating to the results page" do
+        click_link I18n.t("decidim.admin.menu.consultations_submenu.results")
+        expect(page).to have_current_path(decidim_admin_action_delegator.results_consultation_path(consultation))
+      end
     end
   end
 


### PR DESCRIPTION
That is, the work done on #88 and #89.
    
This allows me to deploy this new feature as it is but not release it yet. It still needs customer validation but in the meantime, we need to keep working on other improvements and we don't want to have long-lived branches. It never ends well.
    
Also, this won't interfere with other organizations using this module.
