### PR TITLE
Fix not showing unpublished responses

### DIFF
--- a/app/queries/decidim/action_delegator/published_responses.rb
+++ b/app/queries/decidim/action_delegator/published_responses.rb
@@ -13,7 +13,6 @@ module Decidim
         Consultations::Response
           .joins(question: :consultation)
           .merge(Consultation.finished)
-          .merge(Consultation.results_published)
           .where(decidim_consultations_questions: { decidim_consultation_id: consultation.id })
           .where.not(decidim_consultations_questions: { published_at: nil })
       end

--- a/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe Admin::ConsultationsController, type: :controller do
+      routes { Decidim::ActionDelegator::AdminEngine.routes }
+
+      let(:organization) { create(:organization) }
+      let(:consultation) { create(:consultation, organization: organization) }
+      let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+      before do
+        request.env["decidim.current_organization"] = organization
+        sign_in user
+      end
+
+      describe "#results" do
+        let(:question) { create(:question, consultation: consultation) }
+        let(:question_response) { create(:response, question: question, title: { "ca" => "A" }) }
+
+        before do
+          question.votes.create(author: user, response: question_response)
+        end
+
+        it "renders decidim/admin/consultation layout" do
+          get :results, params: { slug: consultation.slug }
+          expect(response).to render_template("layouts/decidim/admin/consultation")
+        end
+
+        context "when the consultation is not finished" do
+          let(:consultation) { create(:consultation, :unpublished, organization: organization) }
+
+          it "does not load any response" do
+            get :results, params: { slug: consultation.slug }
+            expect(assigns(:responses)).to be_empty
+          end
+        end
+
+        context "when the consultation is finished" do
+          let(:consultation) { create(:consultation, :finished, organization: organization) }
+
+          it "loads the responses" do
+            get :results, params: { slug: consultation.slug }
+            expect(assigns(:responses)).not_to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/decidim/action_delegator/published_responses_spec.rb
+++ b/spec/queries/decidim/action_delegator/published_responses_spec.rb
@@ -24,29 +24,38 @@ module Decidim::ActionDelegator
         end
       end
 
-      context "when the consultation is finished" do
+      context "when the consultation is not published but ended" do
+        let(:consultation) do
+          create(:consultation, :unpublished, end_voting_date: 1.day.ago, organization: organization)
+        end
+
+        it "returns empty" do
+          expect(subject.query).to be_empty
+        end
+      end
+
+      context "when the consultation is published but not ended" do
+        let(:consultation) do
+          create(:consultation, :published, end_voting_date: 1.day.from_now, organization: organization)
+        end
+
+        it "returns empty" do
+          expect(subject.query).to be_empty
+        end
+      end
+
+      context "when the consultation is published and ended" do
+        let(:consultation) { create(:consultation, :finished, organization: organization) }
+
         context "and the questions are published" do
           let!(:question) { create(:question, :published, consultation: consultation) }
 
-          context "and the results are published" do
-            let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
-
-            it "returns the responses to its questions" do
-              expect(subject.query).to match_array([response])
-            end
-          end
-
-          context "and the results are not published" do
-            let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
-
-            it "returns empty" do
-              expect(subject.query).to be_empty
-            end
+          it "returns the responses to its questions" do
+            expect(subject.query).to match_array([response])
           end
         end
 
         context "and the questions are not published" do
-          let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
           let!(:question) { create(:question, :unpublished, consultation: consultation) }
 
           it "returns empty" do

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -8,9 +8,9 @@ describe "Admin manages consultation results", type: :system do
 
   let(:total_votes) { I18n.t("decidim.admin.consultations.results.total_votes", count: votes) }
 
-  let!(:question) { create(:question, consultation: consultation) }
-  let!(:response) { create(:response, question: question, title: { "ca" => "A" }) }
-  let!(:other_response) { create(:response, question: question, title: { "ca" => "B" }) }
+  let(:question) { create(:question, consultation: consultation) }
+  let(:response) { create(:response, question: question, title: { "ca" => "A" }) }
+  let(:other_response) { create(:response, question: question, title: { "ca" => "B" }) }
 
   let!(:other_user) { create(:user, :admin, :confirmed, organization: organization) }
   let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }


### PR DESCRIPTION
Although it was required for the consultation to have its results published, the code wasn't taking effect due to a bug.

Because the `ActiveRecord::Relation` output by `PublishedResponses` was empty, `ResponsesByMembership` took that relation as a nil, and therefore, the default value `Decidim::Consultations::Response` was being used thus, loading all responses from all consultations in the DB. You can see this in 9bce895.

Since we load and iterate over questions and responses separately, and the questions were properly scoped by consultation, we were only rendering the matching responses and not all of them.

This fixes all this mess. As a result, there's no need to publish the results for admins to see the outcomes of the consultation.