### PR TITLE
Load total_participants from the questions query

### DIFF
--- a/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
@@ -20,7 +20,14 @@ module Decidim
         end
 
         def questions
-          current_consultation.questions.published.includes(:responses)
+          current_consultation
+            .questions
+            .published
+            .includes(:responses)
+            .left_joins(:votes)
+            .group("decidim_consultations_questions.id")
+            .select("decidim_consultations_questions.*")
+            .select("COUNT(DISTINCT(decidim_consultations_votes.decidim_author_id)) as num_participants")
         end
 
         def responses

--- a/app/views/decidim/action_delegator/admin/consultations/results.html.erb
+++ b/app/views/decidim/action_delegator/admin/consultations/results.html.erb
@@ -32,7 +32,7 @@
                 /
                 <%= t 'decidim.admin.consultations.results.total_delegates', count: Decidim::ActionDelegator::DelegatesVotesByQuestion.new(question).query %>
                 /
-                <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
+                <%= t "decidim.admin.consultations.results.participants", count: question.num_participants %>
               </th>
             </tr>
           </thead>

--- a/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
@@ -41,6 +41,12 @@ module Decidim
         context "when the consultation is finished" do
           let(:consultation) { create(:consultation, :finished, organization: organization) }
 
+          it "loads the question's total participants without an N+1" do
+            get :results, params: { slug: consultation.slug }
+            questions = assigns(:questions)
+            expect(questions.first.num_participants).to eq(1)
+          end
+
           it "loads the responses" do
             get :results, params: { slug: consultation.slug }
             expect(assigns(:responses)).not_to be_empty


### PR DESCRIPTION
Related to #51. This fixes an N+1 caused by `Decidim::Consultations::Question#total_participants` which looks like:

```sql
SELECT COUNT(DISTINCT "decidim_consultations_votes"."decidim_author_id")
FROM "decidim_consultations_votes"
WHERE "decidim_consultations_votes"."decidim_consultation_question_id" = $1
[["decidim_consultation_question_id", 5]]
```