### PR TITLE
Export sum of weights

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -716,7 +716,7 @@ Layout/MultilineMethodCallBraceLayout:
     - same_line
 
 Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: aligned
+  EnforcedStyle: indented
   SupportedStyles:
     - aligned
     - indented

--- a/app/commands/decidim/action_delegator/admin/create_delegation.rb
+++ b/app/commands/decidim/action_delegator/admin/create_delegation.rb
@@ -49,8 +49,8 @@ module Decidim
 
         def grants_count
           SettingDelegations.new(current_setting).query
-                            .where(grantee_id: form.grantee_id)
-                            .count
+            .where(grantee_id: form.grantee_id)
+            .count
         end
 
         def create_delegation

--- a/app/controllers/decidim/action_delegator/admin/consultations/exports_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations/exports_controller.rb
@@ -11,10 +11,14 @@ module Decidim
           def create
             enforce_permission_to :export_consultation_results, :consultation, consultation: current_consultation
 
-            ExportConsultationResultsJob.perform_later(current_user, current_consultation, "type_and_weight")
+            ExportConsultationResultsJob.perform_later(current_user, current_consultation, type)
 
             flash[:notice] = t("decidim.admin.exports.notice")
             redirect_back(fallback_location: decidim_admin_consultations.results_consultation_path(current_consultation))
+          end
+
+          def type
+            "type_and_weight"
           end
         end
       end

--- a/app/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller.rb
@@ -4,17 +4,9 @@ module Decidim
   module ActionDelegator
     module Admin
       module Exports
-        class SumOfWeightsController < ActionDelegator::Admin::ApplicationController
-          include NeedsPermission
-          include Decidim::Consultations::NeedsConsultation
-
-          def create
-            enforce_permission_to :export_consultation_results, :consultation, consultation: current_consultation
-
-            ExportConsultationResultsJob.perform_later(current_user, current_consultation, "sum_of_weights")
-
-            flash[:notice] = t("decidim.admin.exports.notice")
-            redirect_back(fallback_location: decidim_admin_consultations.results_consultation_path(current_consultation))
+        class SumOfWeightsController < Admin::Consultations::ExportsController
+          def type
+            "sum_of_weights"
           end
         end
       end

--- a/app/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller.rb
@@ -3,15 +3,15 @@
 module Decidim
   module ActionDelegator
     module Admin
-      module Consultations
-        class ExportsController < ActionDelegator::Admin::ApplicationController
+      module Exports
+        class SumOfWeightsController < ActionDelegator::Admin::ApplicationController
           include NeedsPermission
           include Decidim::Consultations::NeedsConsultation
 
           def create
             enforce_permission_to :export_consultation_results, :consultation, consultation: current_consultation
 
-            ExportConsultationResultsJob.perform_later(current_user, current_consultation, "type_and_weight")
+            ExportConsultationResultsJob.perform_later(current_user, current_consultation, "sum_of_weights")
 
             flash[:notice] = t("decidim.admin.exports.notice")
             redirect_back(fallback_location: decidim_admin_consultations.results_consultation_path(current_consultation))

--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -11,7 +11,7 @@ module Decidim
             enforce_permission_to :read, :consultation, consultation: current_consultation
 
             @questions = questions
-            @responses = responses.group_by(&:decidim_consultations_questions_id)
+            @responses = responses.group_by(&:question_id)
 
             render layout: "decidim/admin/consultation"
           end
@@ -27,11 +27,7 @@ module Decidim
           end
 
           def responses
-            SumOfMembershipWeight.new(published_questions_responses).query
-          end
-
-          def published_questions_responses
-            VotedWithDirectVerification.new(PublishedResponses.new(current_consultation).query).query
+            SumOfWeights.new(current_consultation).query
           end
         end
       end

--- a/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
+++ b/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
@@ -5,11 +5,14 @@ module Decidim
     class ExportConsultationResultsJob < ApplicationJob
       queue_as :default
 
-      def perform(user, consultation)
+      def perform(user, consultation, relation = nil)
         @consultation = consultation
+        data = relation.presence || collection
 
-        export_data = Decidim::Exporters.find_exporter("CSV").new(collection, serializer).export
-        ExportMailer.export(user, I18n.t("decidim.admin.consultations.results.export_filename"), export_data).deliver_now
+        export_data = Decidim::Exporters.find_exporter("CSV").new(data, serializer).export
+        ExportMailer
+          .export(user, I18n.t("decidim.admin.consultations.results.export_filename"), export_data)
+          .deliver_now
       end
 
       private

--- a/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
+++ b/app/jobs/decidim/action_delegator/export_consultation_results_job.rb
@@ -5,33 +5,46 @@ module Decidim
     class ExportConsultationResultsJob < ApplicationJob
       queue_as :default
 
-      def perform(user, consultation, relation = nil)
+      def perform(user, consultation, results_type)
         @consultation = consultation
-        data = relation.presence || collection
+        @results_type = results_type.to_sym
 
-        export_data = Decidim::Exporters.find_exporter("CSV").new(data, serializer).export
-        ExportMailer
-          .export(user, I18n.t("decidim.admin.consultations.results.export_filename"), export_data)
-          .deliver_now
+        export_data = Decidim::Exporters
+          .find_exporter("CSV")
+          .new(collection, serializer)
+          .export
+
+        ExportMailer.export(user, filename, export_data).deliver_now
       end
 
       private
 
-      attr_reader :consultation
+      attr_reader :consultation, :results_type
 
       def collection
-        relation = VotedWithDirectVerification.new(published_questions_responses).query
-        ResponsesByMembership.new(relation).query
+        query_class.new(consultation).query
       end
 
-      # Returns the published questions' responses of the given consultation as an ActiveRecord
-      # Relation. Note this enables us to the chain it with other AR Relation objects.
-      def published_questions_responses
-        PublishedResponses.new(consultation).query
+      def query_class
+        case results_type
+        when :sum_of_weights
+          SumOfWeights
+        when :type_and_weight
+          TypeAndWeight
+        end
       end
 
       def serializer
-        ConsultationResultsSerializer
+        case results_type
+        when :sum_of_weights
+          SumOfWeightsSerializer
+        when :type_and_weight
+          ConsultationResultsSerializer
+        end
+      end
+
+      def filename
+        I18n.t("decidim.admin.consultations.results.export_filename")
       end
     end
   end

--- a/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
+++ b/app/queries/decidim/action_delegator/sum_of_membership_weight.rb
@@ -12,20 +12,26 @@ module Decidim
       def query
         relation
           .select(
-            responses[:decidim_consultations_questions_id],
+            questions[:id].as("question_id"),
+            questions[:title].as("question_title"),
             responses[:title],
             votes_count
           )
           .group(
-            responses[:decidim_consultations_questions_id],
+            questions[:id],
+            questions[:title],
             responses[:title]
           )
-          .order(:title)
+          .order(responses[:title])
       end
 
       private
 
       attr_reader :relation
+
+      def questions
+        Consultations::Question.arel_table
+      end
 
       def responses
         Decidim::Consultations::Response.arel_table

--- a/app/queries/decidim/action_delegator/sum_of_weights.rb
+++ b/app/queries/decidim/action_delegator/sum_of_weights.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class SumOfWeights < Rectify::Query
+      def initialize(consultation)
+        @consultation = consultation
+      end
+
+      def query
+        SumOfMembershipWeight.new(published_questions_responses).query
+      end
+
+      private
+
+      attr_reader :consultation
+
+      def published_questions_responses
+        VotedWithDirectVerification.new(
+          PublishedResponses.new(consultation).query
+        ).query
+      end
+    end
+  end
+end

--- a/app/queries/decidim/action_delegator/type_and_weight.rb
+++ b/app/queries/decidim/action_delegator/type_and_weight.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class TypeAndWeight < Rectify::Query
+      def initialize(consultation)
+        @consultation = consultation
+      end
+
+      def query
+        relation = VotedWithDirectVerification.new(published_questions_responses).query
+        ResponsesByMembership.new(relation).query
+      end
+
+      private
+
+      attr_reader :consultation
+
+      # Returns the published questions' responses of the given consultation as an ActiveRecord
+      # Relation. Note this enables us to the chain it with other AR Relation objects.
+      def published_questions_responses
+        PublishedResponses.new(consultation).query
+      end
+    end
+  end
+end

--- a/app/serializers/decidim/action_delegator/sum_of_weights_serializer.rb
+++ b/app/serializers/decidim/action_delegator/sum_of_weights_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class SumOfWeightsSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+
+      def serialize
+        {
+          question: translated_attribute(resource.question_title),
+          response: translated_attribute(resource.title),
+          votes_count: resource.votes_count
+        }
+      end
+    end
+  end
+end

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -11,7 +11,12 @@
       </span>
       <span id="export-consultation-results" class="button--title">
         <% if allowed_to?(:export_consultation_results, :consultation, consultation: current_consultation) %>
-          <%= link_to t("decidim.admin.consultations.results.export"), decidim_admin_action_delegator.consultation_exports_path(current_consultation), method: :post, class: "button tiny button--title" %>
+          <%= link_to(
+            t("decidim.admin.consultations.results.export"),
+            decidim_admin_action_delegator.consultation_exports_sum_of_weights_path(current_consultation),
+            method: :post,
+            class: "button tiny button--title"
+          ) %>
         <% else %>
           <span class="button tiny button--title disabled"><%= t("decidim.admin.consultations.results.export") %></span>
         <% end %>

--- a/lib/decidim/action_delegator/admin_engine.rb
+++ b/lib/decidim/action_delegator/admin_engine.rb
@@ -18,6 +18,10 @@ module Decidim
           get :results, on: :member
           resources :exports, only: [:create], module: :consultations
 
+          namespace :exports do
+            resources :sum_of_weights, only: :create
+          end
+
           namespace :results do
             resources :sum_of_weights, only: :index
           end

--- a/spec/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/shared_examples/export_controller"
 
 module Decidim
   module ActionDelegator
@@ -18,31 +19,7 @@ module Decidim
         end
 
         describe "#create" do
-          it "authorizes the action" do
-            expect(controller).to receive(:allowed_to?)
-              .with(:export_consultation_results, :consultation, consultation: consultation)
-
-            post :create, params: { consultation_slug: consultation.slug }
-          end
-
-          it "enqueues a ExportConsultationResultsJob" do
-            expect(ExportConsultationResultsJob).to receive(:perform_later)
-              .with(user, consultation, "sum_of_weights")
-
-            post :create, params: { consultation_slug: consultation.slug }
-          end
-
-          it "redirects back" do
-            request.env["HTTP_REFERER"] = "referer"
-            post :create, params: { consultation_slug: consultation.slug }
-
-            expect(response).to redirect_to("referer")
-          end
-
-          it "returns a flash notice" do
-            post :create, params: { consultation_slug: consultation.slug }
-            expect(flash[:notice]).to eq(I18n.t("decidim.admin.exports.notice"))
-          end
+          it_behaves_like "results export controller", "sum_of_weights"
         end
       end
     end

--- a/spec/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/exports/sum_of_weights_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    module Admin
+      describe Exports::SumOfWeightsController, type: :controller do
+        routes { Decidim::ActionDelegator::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+        let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in user
+        end
+
+        describe "#create" do
+          it "authorizes the action" do
+            expect(controller).to receive(:allowed_to?)
+              .with(:export_consultation_results, :consultation, consultation: consultation)
+
+            post :create, params: { consultation_slug: consultation.slug }
+          end
+
+          it "enqueues a ExportConsultationResultsJob" do
+            expect(ExportConsultationResultsJob).to receive(:perform_later)
+              .with(user, consultation, "sum_of_weights")
+
+            post :create, params: { consultation_slug: consultation.slug }
+          end
+
+          it "redirects back" do
+            request.env["HTTP_REFERER"] = "referer"
+            post :create, params: { consultation_slug: consultation.slug }
+
+            expect(response).to redirect_to("referer")
+          end
+
+          it "returns a flash notice" do
+            post :create, params: { consultation_slug: consultation.slug }
+            expect(flash[:notice]).to eq(I18n.t("decidim.admin.exports.notice"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:user) { create(:user, :admin, :confirmed, organization: organization) }
-      let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+      let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
 
       before do
         request.env["decidim.current_organization"] = organization
@@ -18,8 +18,14 @@ module Decidim
 
       describe "#create" do
         it "authorizes the action" do
-          expect(controller).to receive(:allowed_to?).with(:export_consultation_results, :consultation, consultation: consultation)
+          expect(controller).to receive(:allowed_to?)
+            .with(:export_consultation_results, :consultation, consultation: consultation)
 
+          post :create, params: { consultation_slug: consultation.slug }
+        end
+
+        it "enqueues a ExportConsultationResultsJob" do
+          expect(ExportConsultationResultsJob).to receive(:perform_later).with(user, consultation)
           post :create, params: { consultation_slug: consultation.slug }
         end
       end

--- a/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:user) { create(:user, :admin, :confirmed, organization: organization) }
-      let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+      let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
 
       before do
         request.env["decidim.current_organization"] = organization

--- a/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/exports_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/shared_examples/export_controller"
 
 module Decidim
   module ActionDelegator
@@ -9,7 +10,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:user) { create(:user, :admin, :confirmed, organization: organization) }
-      let(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+      let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
 
       before do
         request.env["decidim.current_organization"] = organization
@@ -17,17 +18,7 @@ module Decidim
       end
 
       describe "#create" do
-        it "authorizes the action" do
-          expect(controller).to receive(:allowed_to?)
-            .with(:export_consultation_results, :consultation, consultation: consultation)
-
-          post :create, params: { consultation_slug: consultation.slug }
-        end
-
-        it "enqueues a ExportConsultationResultsJob" do
-          expect(ExportConsultationResultsJob).to receive(:perform_later).with(user, consultation)
-          post :create, params: { consultation_slug: consultation.slug }
-        end
+        it_behaves_like "results export controller", "type_and_weight"
       end
     end
   end

--- a/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
@@ -41,13 +41,10 @@ module Decidim::ActionDelegator
 
     describe "#perform" do
       let(:mailer) { double(:mailer, deliver_now: true) }
-      let(:serializer) { ConsultationResultsSerializer }
+      let(:exporter_class) { class_double(Decidim::Exporters::CSV) }
+      let(:exporter) { instance_double(Decidim::Exporters::CSV, export: export_data) }
 
-      context "when a relation is not passed" do
-        let(:collection) { double(:collection) }
-
-        let(:exporter_class) { class_double(Decidim::Exporters::CSV) }
-        let(:exporter) { instance_double(Decidim::Exporters::CSV, export: export_data) }
+      context "when passing type_and_weight" do
         let(:export_data) do
           double(
             :export_data,
@@ -55,13 +52,22 @@ module Decidim::ActionDelegator
           )
         end
 
-        before do
-          allow_any_instance_of(ResponsesByMembership).to receive(:query).and_return(collection)
-          allow(exporter_class).to receive(:new).with(collection, serializer).and_return(exporter)
-          allow(Decidim::Exporters).to receive(:find_exporter).with("CSV").and_return(exporter_class)
+        it "fetches data calling TypeAndWeight" do
+          type_and_weight = instance_double(TypeAndWeight)
+          expect(TypeAndWeight)
+            .to receive(:new).with(consultation).and_return(type_and_weight)
+          expect(type_and_weight).to receive(:query).and_return([])
+
+          subject.perform_now(user, consultation, :type_and_weight)
         end
 
         it "sends an export mail from the collection data" do
+          allow(exporter_class).to receive(:new)
+            .with(kind_of(ActiveRecord::Relation), ConsultationResultsSerializer)
+            .and_return(exporter)
+          allow(Decidim::Exporters).to receive(:find_exporter)
+            .with("CSV").and_return(exporter_class)
+
           expect(Decidim::ExportMailer)
             .to receive(:export)
             .with(
@@ -71,7 +77,7 @@ module Decidim::ActionDelegator
             )
             .and_return(mailer)
 
-            subject.perform_now(user, consultation)
+            subject.perform_now(user, consultation, :type_and_weight)
         end
 
         context "when the consultation is active" do
@@ -83,13 +89,15 @@ module Decidim::ActionDelegator
               expect(export_data.read).to eq("\n")
             end.and_return(mailer)
 
-            subject.perform_now(user, consultation)
+            subject.perform_now(user, consultation, :type_and_weight)
           end
         end
 
         context "when the consultation is finished" do
           context "and the results are published" do
-            let!(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+            let!(:consultation) do
+              create(:consultation, :finished, :published_results, organization: organization)
+            end
 
             it "exports consultation's by membership" do
               expect(Decidim::ExportMailer).to receive(:export) do |_user, _name, export_data|
@@ -102,25 +110,31 @@ module Decidim::ActionDelegator
                 CSV
               end.and_return(mailer)
 
-              subject.perform_now(user, consultation)
+              subject.perform_now(user, consultation, :type_and_weight)
             end
           end
         end
       end
 
-      context "when a relation is passed" do
-        let(:relation) { ["thing"] }
+      context "when passing sum_of_weights" do
+        let(:export_data) { double(:export_data, read: "data\n") }
 
-        let(:exporter_class) { class_double(Decidim::Exporters::CSV) }
-        let(:exporter) { instance_double(Decidim::Exporters::CSV, export: export_data) }
-        let(:export_data) { double(:export_data, read: "thing\n") }
+        it "fetches data calling SumOfWeights" do
+          sum_of_weights = instance_double(SumOfWeights)
+          expect(SumOfWeights)
+            .to receive(:new).with(consultation).and_return(sum_of_weights)
+          expect(sum_of_weights).to receive(:query).and_return([])
 
-        before do
-          allow(exporter_class).to receive(:new).with(relation, serializer).and_return(exporter)
-          allow(Decidim::Exporters).to receive(:find_exporter).with("CSV").and_return(exporter_class)
+          subject.perform_now(user, consultation, :sum_of_weights)
         end
 
         it "sends an export mail with the collection data" do
+          allow(exporter_class).to receive(:new)
+            .with(kind_of(ActiveRecord::Relation), SumOfWeightsSerializer)
+            .and_return(exporter)
+          allow(Decidim::Exporters).to receive(:find_exporter)
+            .with("CSV").and_return(exporter_class)
+
           expect(Decidim::ExportMailer)
             .to receive(:export)
             .with(
@@ -130,7 +144,37 @@ module Decidim::ActionDelegator
             )
             .and_return(mailer)
 
-            subject.perform_now(user, consultation, relation)
+            subject.perform_now(user, consultation, :sum_of_weights)
+        end
+
+        context "when the consultation is active" do
+          let!(:consultation) { create(:consultation, :active, organization: organization) }
+
+          it "does not export anything" do
+            expect(Decidim::ExportMailer).to receive(:export) do |_user, _name, export_data|
+              expect(export_data.read).to eq("\n")
+            end.and_return(mailer)
+
+            subject.perform_now(user, consultation, :sum_of_weights)
+          end
+        end
+
+        context "when the consultation is finished" do
+          let!(:consultation) do
+            create(:consultation, :finished, :published_results, organization: organization)
+          end
+
+          it "exports consultation's by membership" do
+            expect(Decidim::ExportMailer).to receive(:export) do |_user, _name, export_data|
+              expect(export_data.read).to eq(<<-CSV.strip_heredoc)
+                question;response;votes_count
+                question_title;A;6
+                question_title;B;1
+              CSV
+            end.and_return(mailer)
+
+            subject.perform_now(user, consultation, :sum_of_weights)
+          end
         end
       end
     end

--- a/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
+++ b/spec/jobs/decidim/action_delegator/export_consultation_results_job_spec.rb
@@ -77,7 +77,7 @@ module Decidim::ActionDelegator
             )
             .and_return(mailer)
 
-            subject.perform_now(user, consultation, :type_and_weight)
+          subject.perform_now(user, consultation, :type_and_weight)
         end
 
         context "when the consultation is active" do
@@ -144,7 +144,7 @@ module Decidim::ActionDelegator
             )
             .and_return(mailer)
 
-            subject.perform_now(user, consultation, :sum_of_weights)
+          subject.perform_now(user, consultation, :sum_of_weights)
         end
 
         context "when the consultation is active" do

--- a/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
+++ b/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
@@ -8,7 +8,9 @@ module Decidim
       subject(:query_object) { described_class.new(relation) }
 
       let(:relation) do
-        relation = Decidim::Consultations::Response.where(question: question)
+        relation = Decidim::Consultations::Response
+          .joins(:question)
+          .where(question: question)
         Decidim::ActionDelegator::VotedWithDirectVerification.new(relation).query
       end
 
@@ -25,6 +27,16 @@ module Decidim
       end
 
       describe "#query" do
+        it "returns responses and questions data" do
+          expect(query_object.query.first.attributes).to eq({
+            "id" => nil,
+            "question_id" => question.id,
+            "question_title" => question.title,
+            "title" => response.title,
+            "votes_count" => 2
+          })
+        end
+
         context "when all users have membership" do
           let(:auth_metadata) { { membership_type: "producer", membership_weight: 2 } }
           let(:other_auth_metadata) { { membership_type: "producer", membership_weight: 3 } }

--- a/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
+++ b/spec/queries/decidim/action_delegator/sum_of_membership_weight_spec.rb
@@ -28,13 +28,13 @@ module Decidim
 
       describe "#query" do
         it "returns responses and questions data" do
-          expect(query_object.query.first.attributes).to eq({
+          expect(query_object.query.first.attributes).to eq(
             "id" => nil,
             "question_id" => question.id,
             "question_title" => question.title,
             "title" => response.title,
             "votes_count" => 2
-          })
+          )
         end
 
         context "when all users have membership" do

--- a/spec/serializers/decidim/action_delegator/sum_of_weights_serializer_spec.rb
+++ b/spec/serializers/decidim/action_delegator/sum_of_weights_serializer_spec.rb
@@ -10,7 +10,7 @@ module Decidim::ActionDelegator
         :result,
         question_title: "question title",
         title: { "ca" => "A" },
-        votes_count: 2,
+        votes_count: 2
       )
     end
 

--- a/spec/serializers/decidim/action_delegator/sum_of_weights_serializer_spec.rb
+++ b/spec/serializers/decidim/action_delegator/sum_of_weights_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ActionDelegator
+  describe SumOfWeightsSerializer do
+    let(:subject) { described_class.new(result) }
+    let(:result) do
+      double(
+        :result,
+        question_title: "question title",
+        title: { "ca" => "A" },
+        votes_count: 2,
+      )
+    end
+
+    describe "#serialize" do
+      it "includes all attributes" do
+        expect(subject.serialize).to eq(
+          question: "question title",
+          response: "A",
+          votes_count: 2
+        )
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/export_controller.rb
+++ b/spec/support/shared_examples/export_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "results export controller" do |type|
+  it "authorizes the action" do
+    expect(controller).to receive(:allowed_to?)
+      .with(:export_consultation_results, :consultation, consultation: consultation)
+
+    post :create, params: { consultation_slug: consultation.slug }
+  end
+
+  it "enqueues a ExportConsultationResultsJob" do
+    expect(Decidim::ActionDelegator::ExportConsultationResultsJob)
+      .to receive(:perform_later)
+      .with(user, consultation, type)
+
+    post :create, params: { consultation_slug: consultation.slug }
+  end
+
+  it "redirects back" do
+    request.env["HTTP_REFERER"] = "referer"
+    post :create, params: { consultation_slug: consultation.slug }
+
+    expect(response).to redirect_to("referer")
+  end
+
+  it "returns a flash notice" do
+    post :create, params: { consultation_slug: consultation.slug }
+    expect(flash[:notice]).to eq(I18n.t("decidim.admin.exports.notice"))
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -99,6 +99,11 @@ describe "Admin manages consultation results", type: :system do
         click_link I18n.t("decidim.admin.menu.consultations_submenu.results")
         expect(page).to have_current_path(decidim_admin_action_delegator.results_consultation_path(consultation))
       end
+
+      it "disables navigation to any other results page" do
+        expect(page)
+          .not_to have_link(I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.by_answer"))
+      end
     end
   end
 

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -92,6 +92,18 @@ describe "Admin manages consultation results", type: :system do
 
         expect(page).to have_current_path(decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation))
       end
+
+      context "when viewing a finished consultation from the sum of weights page" do
+        it "enables exporting to CSV" do
+          click_link I18n.t("decidim.action_delegator.admin.menu.consultations_submenu.sum_of_weights")
+          perform_enqueued_jobs { click_link(I18n.t("decidim.admin.consultations.results.export")) }
+
+          expect(page).to have_content(I18n.t("decidim.admin.exports.notice"))
+
+          expect(last_email.subject).to include("results", "csv")
+          expect(last_email.attachments.first.filename).to match(/^consultation_results.*\.zip$/)
+        end
+      end
     end
 
     context "when RESULTS_NAV is off" do


### PR DESCRIPTION
Closes #87 . It does so by passing in the type of export to perform. That type is used in the job class to choose which query object and serializer pair is used. That's what changes between the two different results views.

The routes follow the same approach we adopted for the results pages. A controller (and endpoint) for each view.