### PR TITLE
Export results in admin also when unpublished

### DIFF
--- a/app/permissions/decidim/action_delegator/permissions.rb
+++ b/app/permissions/decidim/action_delegator/permissions.rb
@@ -12,11 +12,7 @@ module Decidim
         return permission_action unless permission_action.scope == :admin
         return permission_action unless action_delegator_subject?
 
-        if permission_action.action == :export_consultation_results
-          allow! if consultation.results_published?
-        elsif can_perform_action?
-          allow!
-        end
+        allow! if can_perform_action?
 
         permission_action
       end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -182,22 +182,44 @@ describe "Admin manages consultation results", type: :system do
   context "when viewing an unfinished consultation" do
     let!(:consultation) { create(:consultation, :active, :unpublished_results, organization: organization) }
 
-    it "disables the export button" do
+    it "enables the export button" do
       visit decidim_admin_action_delegator.results_consultation_path(consultation)
 
       within "#export-consultation-results" do
-        expect(page).to have_css(".disabled")
-        expect(page).not_to have_link(I18n.t("decidim.admin.consultations.results.export"))
+        expect(page).not_to have_css(".disabled")
+        expect(page).to have_link(I18n.t("decidim.admin.consultations.results.export"))
       end
     end
 
     it "does not show any response" do
       visit decidim_admin_action_delegator.results_consultation_path(consultation)
-      expect(page).not_to have_content(nth_row(1))
+      expect(page).to have_content(I18n.t("decidim.admin.consultations.results.not_visible"))
+    end
+  end
+
+  context "when viewing a consultation with unpublished results" do
+    let!(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+
+    it "enables the export button" do
+      visit decidim_admin_action_delegator.results_consultation_path(consultation)
+
+      within "#export-consultation-results" do
+        expect(page).not_to have_css(".disabled")
+        expect(page).to have_link(I18n.t("decidim.admin.consultations.results.export"))
+      end
+    end
+
+    it "shows the responses" do
+      visit decidim_admin_action_delegator.results_consultation_path(consultation)
+      expect(page).to have_row(4)
     end
   end
 
   def nth_row(number)
     find(:xpath, ".//table/tbody/tr[#{number}]")
+  end
+
+  def have_row(number)
+    have_xpath(".//table/tbody/tr[#{number}]")
   end
 end

--- a/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/results/sum_of_weights_spec.rb
@@ -54,18 +54,36 @@ describe "Admin manages sum of weight consultation results", type: :system do
   context "when viewing an unfinished consultation" do
     let!(:consultation) { create(:consultation, :active, :unpublished_results, organization: organization) }
 
-    it "disables the export button" do
+    it "enables the export button" do
       visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
 
       within "#export-consultation-results" do
-        expect(page).to have_css(".disabled")
-        expect(page).not_to have_link(I18n.t("decidim.admin.consultations.results.export"))
+        expect(page).not_to have_css(".disabled")
+        expect(page).to have_link(I18n.t("decidim.admin.consultations.results.export"))
       end
     end
 
     it "does not show any response" do
       visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
-      expect(page).not_to have_content(find(:xpath, ".//table/tbody/tr[1]"))
+      expect(page).to have_content(I18n.t("decidim.admin.consultations.results.not_visible"))
+    end
+  end
+
+  context "when viewing a consultation with unpublished results" do
+    let!(:consultation) { create(:consultation, :finished, :unpublished_results, organization: organization) }
+
+    it "disables the export button" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+
+      within "#export-consultation-results" do
+        expect(page).not_to have_css(".disabled")
+        expect(page).to have_link(I18n.t("decidim.admin.consultations.results.export"))
+      end
+    end
+
+    it "shows the responses" do
+      visit decidim_admin_action_delegator.consultation_results_sum_of_weights_path(consultation)
+      expect(page).to have_xpath(".//table/tbody/tr[1]")
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/coopdevs/decidim-module-action_delegator/issues/98. This is an unnecessary restriction.