### PR TITLE
Fix total_delegations and total_participants N+1s on consultation result's page

### DIFF
--- a/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/consultations_controller.rb
@@ -7,7 +7,7 @@ module Decidim
         def results
           enforce_permission_to :read, :consultation, consultation: current_consultation
 
-          @questions = questions
+          @questions = Scrutiny.new(current_consultation).questions
           @responses = responses.group_by(&:decidim_consultations_questions_id)
           @total_delegates = DelegatesVotesByConsultation.new(current_consultation).query
 
@@ -18,10 +18,6 @@ module Decidim
 
         def permission_class_chain
           Decidim.permissions_registry.chain_for(ActionDelegator::Admin::ApplicationController)
-        end
-
-        def questions
-          current_consultation.questions.published.includes(:responses)
         end
 
         def responses

--- a/app/presenters/decidim/action_delegator/question_with_totals.rb
+++ b/app/presenters/decidim/action_delegator/question_with_totals.rb
@@ -9,7 +9,11 @@ module Decidim
       end
 
       def total_delegates
-        questions_by_id[id]
+        questions_by_id[id].total_delegates
+      end
+
+      def total_participants
+        questions_by_id[id].total_participants
       end
 
       private

--- a/app/presenters/decidim/action_delegator/question_with_totals.rb
+++ b/app/presenters/decidim/action_delegator/question_with_totals.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class QuestionWithTotals < SimpleDelegator
+      def initialize(question, questions_by_id)
+        super(question)
+        @questions_by_id = questions_by_id
+      end
+
+      def total_delegates
+        questions_by_id[id]
+      end
+
+      private
+
+      attr_reader :questions_by_id
+    end
+  end
+end

--- a/app/queries/decidim/action_delegator/scrutiny.rb
+++ b/app/queries/decidim/action_delegator/scrutiny.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActionDelegator
+    class Scrutiny
+      def initialize(consultation)
+        @consultation = consultation
+        @question_votes_by_id = questions_query.group_by(&:id)
+      end
+
+      def questions
+        questions_cache = build_questions_cache
+
+        question_votes_by_id.map do |_id, question_votes|
+          # They are all the same question so we can pick any
+          question = question_votes.first
+          QuestionWithTotals.new(question, questions_cache)
+        end
+      end
+
+      private
+
+      attr_reader :consultation, :questions_cache, :question_votes_by_id
+
+      # Returns a hash where the key is the question and the value is the numer of delegated votes
+      # it got.
+      def build_questions_cache
+        question_votes_by_id.each_with_object({}) do |(id, questions), memo|
+          total_delegations = questions.count { |question| question.granter_id.present? }
+          memo[id] = total_delegations
+          memo
+        end
+      end
+
+      def questions_query
+        @questions_query ||= Decidim::Consultations::Question.find_by_sql(<<-SQL.strip_heredoc)
+          SELECT
+            "decidim_consultations_questions".*,
+            "decidim_action_delegator_delegations"."granter_id"
+          FROM "decidim_consultations_questions"
+          LEFT OUTER JOIN "decidim_consultations_votes"
+            ON "decidim_consultations_votes"."decidim_consultation_question_id" = "decidim_consultations_questions"."id"
+          LEFT JOIN "decidim_action_delegator_delegations"
+            ON "decidim_consultations_votes"."decidim_author_id" = "decidim_action_delegator_delegations"."granter_id"
+          LEFT JOIN "decidim_action_delegator_settings"
+            ON "decidim_action_delegator_settings"."id" = "decidim_action_delegator_delegations"."decidim_action_delegator_setting_id"
+          LEFT JOIN "decidim_consultations"
+            ON "decidim_consultations"."id" = "decidim_action_delegator_settings"."decidim_consultation_id"
+          WHERE "decidim_consultations_questions"."decidim_consultation_id" = #{consultation.id}
+            AND "decidim_consultations_questions"."published_at" IS NOT NULL
+          ORDER BY "decidim_consultations_questions"."order" ASC
+        SQL
+      end
+    end
+  end
+end

--- a/app/queries/decidim/action_delegator/scrutiny.rb
+++ b/app/queries/decidim/action_delegator/scrutiny.rb
@@ -31,8 +31,8 @@ module Decidim
 
       attr_reader :consultation, :questions_cache, :question_votes_by_id
 
-      # Returns a hash where the key is the question and the value is the numer of delegated votes
-      # it got.
+      # Returns a hash where the key is the question id and the value is an object that wraps some
+      # question's counts displayed in the view.
       def build_questions_cache
         question_votes_by_id.each_with_object({}) do |(id, question_votes), memo|
           total_delegations = delegations_count(question_votes)
@@ -42,14 +42,20 @@ module Decidim
         end
       end
 
+      # Computes the count of delegated votes out of rows returned by `#questions_query`, named
+      # `question_votes`.
       def delegations_count(question_votes)
         question_votes.count { |question| question.granter_id.present? }
       end
 
+      # Computes the count of participants out of rows returned by `#questions_query`, named
+      # `question_votes`.
       def participants_count(question_votes)
         question_votes.map(&:decidim_author_id).uniq.compact.size
       end
 
+      # Returns questions joined with their votes and delegations so that we can aggregate the data
+      # in Ruby in different ways but reaching out to DB just once.
       def questions_query
         @questions_query ||= Consultations::Question
           .select(

--- a/app/queries/decidim/action_delegator/scrutiny.rb
+++ b/app/queries/decidim/action_delegator/scrutiny.rb
@@ -58,6 +58,7 @@ module Decidim
       # in Ruby in different ways but reaching out to DB just once.
       def questions_query
         @questions_query ||= Consultations::Question
+          .includes(:responses)
           .select(
             '"decidim_consultations_questions".*',
             '"decidim_consultations_votes"."decidim_author_id"',

--- a/app/queries/decidim/action_delegator/scrutiny.rb
+++ b/app/queries/decidim/action_delegator/scrutiny.rb
@@ -34,13 +34,20 @@ module Decidim
       # Returns a hash where the key is the question and the value is the numer of delegated votes
       # it got.
       def build_questions_cache
-        question_votes_by_id.each_with_object({}) do |(id, questions), memo|
-          total_delegations = questions.count { |question| question.granter_id.present? }
-          total_participants = questions.map(&:decidim_author_id).uniq.size
+        question_votes_by_id.each_with_object({}) do |(id, question_votes), memo|
+          total_delegations = delegations_count(question_votes)
+          total_participants = participants_count(question_votes)
 
           memo[id] = QuestionStats.new(total_delegations, total_participants)
-          memo
         end
+      end
+
+      def delegations_count(question_votes)
+        question_votes.count { |question| question.granter_id.present? }
+      end
+
+      def participants_count(question_votes)
+        question_votes.map(&:decidim_author_id).uniq.compact.size
       end
 
       def questions_query

--- a/app/views/decidim/action_delegator/admin/consultations/results.html.erb
+++ b/app/views/decidim/action_delegator/admin/consultations/results.html.erb
@@ -30,7 +30,7 @@
               <th class="table-list__actions">
                 <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
                 /
-                <%= t 'decidim.admin.consultations.results.total_delegates', count: Decidim::ActionDelegator::DelegatesVotesByQuestion.new(question).query %>
+                <%= t 'decidim.admin.consultations.results.total_delegates', count: question.total_delegates %>
                 /
                 <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
               </th>

--- a/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
@@ -41,42 +41,9 @@ module Decidim
         context "when the consultation is finished" do
           let(:consultation) { create(:consultation, :finished, organization: organization) }
 
-          let(:other_question) { create(:question, consultation: consultation) }
-          let(:other_response) { create(:response, question: question) }
-
-          let(:granter) { create(:user, organization: organization) }
-          let(:grantee) { create(:user, organization: organization) }
-          let(:setting) { create(:setting, consultation: consultation) }
-
-          context "when there are no delegations" do
-            before do
-              other_question.votes.create(author: user, response: other_response)
-
-              puts "granter_id = #{granter.id}"
-              puts "other_question = #{other_question.id}"
-
-              create(:delegation, granter_id: granter.id, grantee_id: grantee.id, setting: setting)
-              other_question.votes.create(author: granter, response: other_response)
-            end
-
-            it "loads the question's totals without an N+1" do
-              get :results, params: { slug: consultation.slug }
-              questions = assigns(:questions)
-
-              expect(questions.first.id).to eq(question.id)
-              expect(questions.second.id).to eq(other_question.id)
-
-              expect(questions.first.total_delegates).to eq(0)
-              expect(questions.second.total_delegates).to eq(1)
-
-              expect(questions.first.total_participants).to eq(1)
-              expect(questions.second.total_participants).to eq(2)
-            end
-
-            it "loads the responses" do
-              get :results, params: { slug: consultation.slug }
-              expect(assigns(:responses)).not_to be_empty
-            end
+          it "loads the responses" do
+            get :results, params: { slug: consultation.slug }
+            expect(assigns(:responses)).not_to be_empty
           end
         end
       end

--- a/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
+++ b/spec/controllers/decidim/action_delegator/admin/consultations_controller_spec.rb
@@ -41,9 +41,42 @@ module Decidim
         context "when the consultation is finished" do
           let(:consultation) { create(:consultation, :finished, organization: organization) }
 
-          it "loads the responses" do
-            get :results, params: { slug: consultation.slug }
-            expect(assigns(:responses)).not_to be_empty
+          let(:other_question) { create(:question, consultation: consultation) }
+          let(:other_response) { create(:response, question: question) }
+
+          let(:granter) { create(:user, organization: organization) }
+          let(:grantee) { create(:user, organization: organization) }
+          let(:setting) { create(:setting, consultation: consultation) }
+
+          context "when there are no delegations" do
+            before do
+              other_question.votes.create(author: user, response: other_response)
+
+              puts "granter_id = #{granter.id}"
+              puts "other_question = #{other_question.id}"
+
+              create(:delegation, granter_id: granter.id, grantee_id: grantee.id, setting: setting)
+              other_question.votes.create(author: granter, response: other_response)
+            end
+
+            it "loads the question's totals without an N+1" do
+              get :results, params: { slug: consultation.slug }
+              questions = assigns(:questions)
+
+              expect(questions.first.id).to eq(question.id)
+              expect(questions.second.id).to eq(other_question.id)
+
+              expect(questions.first.total_delegates).to eq(0)
+              expect(questions.second.total_delegates).to eq(1)
+
+              expect(questions.first.total_participants).to eq(1)
+              expect(questions.second.total_participants).to eq(2)
+            end
+
+            it "loads the responses" do
+              get :results, params: { slug: consultation.slug }
+              expect(assigns(:responses)).not_to be_empty
+            end
           end
         end
       end

--- a/spec/presenters/decidim/action_delegator/question_with_totals_spec.rb
+++ b/spec/presenters/decidim/action_delegator/question_with_totals_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe QuestionWithTotals do
+      subject { described_class.new(question, questions_by_id) }
+
+      let(:question) { create(:question) }
+      let(:questions_by_id) { { question.id => 2 } }
+
+      describe "#total_delegates" do
+        it "returns the count of its delegated votes" do
+          expect(subject.total_delegates).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/decidim/action_delegator/question_with_totals_spec.rb
+++ b/spec/presenters/decidim/action_delegator/question_with_totals_spec.rb
@@ -8,11 +8,18 @@ module Decidim
       subject { described_class.new(question, questions_by_id) }
 
       let(:question) { create(:question) }
-      let(:questions_by_id) { { question.id => 2 } }
+      let(:stats) { double(:stats, total_delegates: 2, total_participants: 3) }
+      let(:questions_by_id) { { question.id => stats } }
 
       describe "#total_delegates" do
         it "returns the count of its delegated votes" do
           expect(subject.total_delegates).to eq(2)
+        end
+      end
+
+      describe "#total_participants" do
+        it "returns the count of distinct votes" do
+          expect(subject.total_participants).to eq(3)
         end
       end
     end

--- a/spec/queries/decidim/action_delegator/scrutiny_spec.rb
+++ b/spec/queries/decidim/action_delegator/scrutiny_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ActionDelegator
+    describe Scrutiny do
+      subject { described_class.new(consultation) }
+
+      let(:organization) { create(:organization) }
+      let(:consultation) { create(:consultation, organization: organization) }
+      let(:user) { create(:user, :confirmed, organization: organization) }
+      let(:other_user) { create(:user, :confirmed, organization: organization) }
+
+      describe "#questions" do
+        let(:question) { create(:question, :published, consultation: consultation) }
+        let(:response) { create(:response, question: question) }
+
+        let!(:unvoted_question) { create(:question, :published, consultation: consultation) }
+        let!(:unpublished_question) { create(:question, :unpublished, consultation: consultation) }
+
+        before do
+          question.votes.create(author: user, response: response)
+          question.votes.create(author: other_user, response: response)
+        end
+
+        it "returns the consultation's published questions" do
+          expect(subject.questions.map(&:id)).to contain_exactly(question.id, unvoted_question.id)
+        end
+
+        it "returns each question's stats" do
+          cache = subject.send(:build_questions_cache)
+
+          expect(cache[question.id].total_delegates).to eq(1)
+          expect(cache[question.id].total_participants).to eq(3)
+
+          expect(cache[unvoted_question.id].total_delegates).to eq(0)
+          expect(cache[unvoted_question.id].total_participants).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -135,6 +135,13 @@ describe "Admin manages consultation results", type: :system do
     let!(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
 
     context "without delegated votes" do
+      let(:extra_question) { create(:question, consultation: consultation) }
+      let(:extra_response) { create(:response, question: extra_question) }
+
+      before do
+        extra_question.votes.create(author: user, response: extra_response)
+      end
+
       it "shows votes by membership and weight type" do
         visit decidim_admin_action_delegator.results_consultation_path(consultation)
 
@@ -142,27 +149,31 @@ describe "Admin manages consultation results", type: :system do
         expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_type"))
         expect(page).to have_content(I18n.t("decidim.admin.consultations.results.membership_weight"))
 
+        expect(page).to have_content("Total: 5 votes / 0 delegated votes / 4 participants")
         expect(page).to have_content("Total: 4 votes / 0 delegated votes / 4 participants")
+        expect(page).to have_content("Total: 1 votes / 0 delegated votes / 1 participants")
 
-        expect(nth_row(1).find(".response-title")).to have_content("A")
-        expect(nth_row(1).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(1).find(".membership-weight")).to have_content(3)
-        expect(nth_row(1).find(".votes-count")).to have_content(1)
+        within ".table-list" do
+          expect(nth_row(1).find(".response-title")).to have_content("A")
+          expect(nth_row(1).find(".membership-type")).to have_content("consumer")
+          expect(nth_row(1).find(".membership-weight")).to have_content(3)
+          expect(nth_row(1).find(".votes-count")).to have_content(1)
 
-        expect(nth_row(2).find(".response-title")).to have_content("A")
-        expect(nth_row(2).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(2).find(".membership-weight")).to have_content(1)
-        expect(nth_row(2).find(".votes-count")).to have_content(1)
+          expect(nth_row(2).find(".response-title")).to have_content("A")
+          expect(nth_row(2).find(".membership-type")).to have_content("consumer")
+          expect(nth_row(2).find(".membership-weight")).to have_content(1)
+          expect(nth_row(2).find(".votes-count")).to have_content(1)
 
-        expect(nth_row(3).find(".response-title")).to have_content("A")
-        expect(nth_row(3).find(".membership-type")).to have_content("producer")
-        expect(nth_row(3).find(".membership-weight")).to have_content(2)
-        expect(nth_row(3).find(".votes-count")).to have_content(1)
+          expect(nth_row(3).find(".response-title")).to have_content("A")
+          expect(nth_row(3).find(".membership-type")).to have_content("producer")
+          expect(nth_row(3).find(".membership-weight")).to have_content(2)
+          expect(nth_row(3).find(".votes-count")).to have_content(1)
 
-        expect(nth_row(4).find(".response-title")).to have_content("B")
-        expect(nth_row(4).find(".membership-type")).to have_content("consumer")
-        expect(nth_row(4).find(".membership-weight")).to have_content(1)
-        expect(nth_row(4).find(".votes-count")).to have_content(1)
+          expect(nth_row(4).find(".response-title")).to have_content("B")
+          expect(nth_row(4).find(".membership-type")).to have_content("consumer")
+          expect(nth_row(4).find(".membership-weight")).to have_content(1)
+          expect(nth_row(4).find(".votes-count")).to have_content(1)
+        end
       end
 
       it "enables exporting to CSV" do
@@ -269,15 +280,11 @@ describe "Admin manages consultation results", type: :system do
 
     it "shows the responses" do
       visit decidim_admin_action_delegator.results_consultation_path(consultation)
-      expect(page).to have_row(4)
+      expect(page).to have_xpath(".//table/tbody[1]/tr[4]")
     end
   end
 
   def nth_row(number)
-    find(:xpath, ".//table/tbody/tr[#{number}]")
-  end
-
-  def have_row(number)
-    have_xpath(".//table/tbody/tr[#{number}]")
+    find(:xpath, ".//tbody[1]/tr[#{number}]")
   end
 end


### PR DESCRIPTION
Navigating to http://decidim.local:3000/admin/action_delegator/consultations/velit-officiis/results, and after a couple of warm-up refreshes. After this change, I systematically get response times around 450ms.

There a few more N+1s left but most importantly, this PR sets the foundation to squash them all.

## Before

![before](https://user-images.githubusercontent.com/762088/121658630-ce9eef80-caa1-11eb-81b9-e5e9a5513933.png)


## After

![Screenshot from 2021-06-11 15-37-05](https://user-images.githubusercontent.com/762088/121694961-e76fcb00-caca-11eb-87dd-18eca0b7ced0.png)
