### PR TITLE
Fix Sum of Weights results N+1s

### DIFF
--- a/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
+++ b/app/controllers/decidim/action_delegator/admin/results/sum_of_weights_controller.rb
@@ -10,7 +10,7 @@ module Decidim
 
             enforce_permission_to :read, :consultation, consultation: current_consultation
 
-            @questions = questions
+            @questions = Scrutiny.new(current_consultation).questions
             @responses = responses.group_by(&:question_id)
             @total_delegates = DelegatesVotesByConsultation.new(current_consultation).query
 

--- a/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
+++ b/app/views/decidim/action_delegator/admin/results/sum_of_weights/index.html.erb
@@ -33,7 +33,7 @@
               <th class="table-list__actions">
                 <%= t "decidim.admin.consultations.results.total_votes", count: question.total_votes %>
                 /
-                <%= t 'decidim.admin.consultations.results.total_delegates', count: Decidim::ActionDelegator::DelegatesVotesByQuestion.new(question).query %>
+                <%= t 'decidim.admin.consultations.results.total_delegates', count: question.total_delegates %>
                 /
                 <%= t "decidim.admin.consultations.results.participants", count: question.total_participants %>
               </th>


### PR DESCRIPTION
This applies the improvements done on the `consultations/:slug/results` page to `consultations/assemblea2020/results/sum_of_weights`.