### PR TITLE
fix duplicated questions when highlighted scope matches

### DIFF
--- a/app/overrides/decidim/consultations/consultations/_regular_questions/remove_highlighted_scopes.html.erb.deface
+++ b/app/overrides/decidim/consultations/consultations/_regular_questions/remove_highlighted_scopes.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- replace 'h3.heading6' -->
+
+<% next if current_consultation.highlighted_scope == questions.first.scope %>
+<h3 class="heading6"><%= translated_attribute questions&.first&.scope&.name %></h3>

--- a/spec/system/consutation_fixes_spec.rb
+++ b/spec/system/consutation_fixes_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Visit a consultation", type: :system do
+  let(:organization) { create :organization, available_locales: [:en] }
+  let!(:consultation) { create :consultation, :published, organization: organization }
+  let!(:question) { create :question, consultation: consultation }
+  let!(:hihglighted_question) { create :question, consultation: consultation, decidim_scope_id: consultation.decidim_highlighted_scope_id }
+  let(:user) { create :user, :confirmed, :admin, organization: organization }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when public view" do
+    shared_examples "renders questions" do
+      it "renders the questions once only" do
+        expect(page).to have_content(translated(question.title), count: 1)
+        expect(page).to have_content(translated(hihglighted_question.title), count: 1)
+      end
+    end
+
+    before do
+      visit decidim_consultations.consultation_path(consultation)
+    end
+
+    it_behaves_like "renders questions"
+
+    context "when question has no scopes" do
+      let(:question) { create :question, consultation: consultation, decidim_scope_id: nil }
+
+      it_behaves_like "renders questions"
+    end
+  end
+
+  context "when admin" do
+    before do
+      login_as user, scope: :user
+      visit decidim_admin_consultations.consultations_path
+    end
+
+    it "does not show the deprecation warning" do
+      expect(page).not_to have_content("Consultations module will be deprecated in the near future.")
+    end
+  end
+end

--- a/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
+++ b/spec/system/decidim/action_delegator/admin/admin_manages_consultation_results_spec.rb
@@ -38,23 +38,11 @@ describe "Admin manages consultation results", type: :system do
     login_as user, scope: :user
   end
 
-  shared_examples "handles the deprecation warning" do
-    it "does not show the warning" do
-      expect(page).not_to have_content("Consultations module will be deprecated in the near future.")
-    end
-  end
-
-  it_behaves_like "handles the deprecation warning" do
-    before { visit decidim_admin_consultations.consultations_path }
-  end
-
   context "when in the consultation page" do
     before do
       visit decidim_admin_consultations.edit_consultation_path(consultation)
       click_link "Results"
     end
-
-    it_behaves_like "handles the deprecation warning"
 
     it "enables navigating to the default results page" do
       click_link I18n.t("decidim.admin.menu.consultations_submenu.results")


### PR DESCRIPTION
fixes a bug in consultations that duplicates the question if matches the highlighed scope of the consultation