### PR TITLE
Implement weighted results display on public interface

### DIFF
--- a/app/models/concerns/decidim/action_delegator/consultations/question_override.rb
+++ b/app/models/concerns/decidim/action_delegator/consultations/question_override.rb
@@ -11,6 +11,24 @@ module Decidim
           def publishable_results?
             (ActionDelegator.admin_preview_results || consultation.finished?) && sorted_results.any?
           end
+
+          def weighted_responses
+            @weighted_responses ||= Decidim::ActionDelegator::SumOfWeights.new(consultation).query.group_by(&:question_id)
+          end
+
+          def total_weighted_votes
+            @total_weighted_votes ||= weighted_responses[id].sum(&:votes_count)
+          end
+
+          def most_weighted_voted_response
+            weighted_responses[id].max_by(&:votes_count)
+          end
+
+          def responses_sorted_by_weighted_votes
+            @responses_sorted_by_weighted_votes ||= weighted_responses.transform_values do |responses|
+              responses.sort_by { |response| -response.votes_count }
+            end
+          end
         end
       end
     end

--- a/app/overrides/decidim/consultations/consultations/_question/replace_vote_info.html.erb.deface
+++ b/app/overrides/decidim/consultations/consultations/_question/replace_vote_info.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- replace_contents "erb[silent]:contains('if question.results_published?')"
+     closing_selector "erb[silent]:contains('else')" -->
+
+<%= render partial: "decidim/action_delegator/consultations/link_with_results", locals: { question: question } %>

--- a/app/overrides/decidim/consultations/questions/_results/replace_results.html.erb.deface
+++ b/app/overrides/decidim/consultations/questions/_results/replace_results.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- replace_contents ".card--list" -->
+
+<%= render partial: "decidim/action_delegator/consultations/questions/weight_results", locals: { response: response, question: question } %>

--- a/app/views/decidim/action_delegator/consultations/_link_with_results.html.erb
+++ b/app/views/decidim/action_delegator/consultations/_link_with_results.html.erb
@@ -1,0 +1,11 @@
+<%= link_to decidim_consultations.question_path(question), class: "button expanded button--sc" do %>
+  <%= t "consultations.question.view_results", scope: "decidim" %>
+  <% if question.most_weighted_voted_response.present? %>
+    <span class="button__info"><%= translated_attribute question.most_weighted_voted_response.title %></span>
+    <span class="button__info">
+      <%= question.most_weighted_voted_response.votes_count %>
+      <%= t "consultations.question.votes_out_of", scope: "decidim", count: question.most_weighted_voted_response.votes_count %>
+      <%= question.total_weighted_votes %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/decidim/action_delegator/consultations/questions/_weight_results.html.erb
+++ b/app/views/decidim/action_delegator/consultations/questions/_weight_results.html.erb
@@ -1,0 +1,8 @@
+<% question.responses_sorted_by_weighted_votes[question.id].each do |response| %>
+  <div class=card--list__item>
+    <div class="card--list__text"><%= translated_attribute response.title %></div>
+    <div class="card--list__data">
+      <span class="card--list__data__number"><%= response.votes_count %></span>
+    </div>
+  </div>
+<% end %>

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -19,6 +19,7 @@ module Decidim::ActionDelegator
         "/app/views/decidim/consultations/questions/_vote_modal.html.erb" => "bb4b10e9278cffd8d0d4eb57f5197a89",
         "/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb" => "bac38cece8f1eaf76265fa1ad0ace064",
         "/app/views/decidim/consultations/question_multiple_votes/_form.html.erb" => "af610283ce7ee20f5ef786228a263d4a",
+        "/app/views/decidim/consultations/questions/_results.html.erb" => "2d8196efbf23e2ad7b8c32713c28b240",
         # monkeypatches
         "/app/commands/decidim/consultations/vote_question.rb" => "bb0489e93d3bd142db19d9f93f556d67",
         "/app/commands/decidim/consultations/multiple_vote_question.rb" => "86ac61db829acb4e86a9b6d90bd46333",

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -24,6 +24,7 @@ module Decidim::ActionDelegator
         "/app/commands/decidim/consultations/vote_question.rb" => "bb0489e93d3bd142db19d9f93f556d67",
         "/app/commands/decidim/consultations/multiple_vote_question.rb" => "86ac61db829acb4e86a9b6d90bd46333",
         "/app/models/decidim/consultations/vote.rb" => "c06286e3f7366d3a017bf69f1c9e3eef",
+        "/app/models/decidim/consultations/question.rb" => "bc6e8618100f112c1d23bee9aaf5c0ed",
         "/app/controllers/decidim/consultations/question_votes_controller.rb" => "69bf764e99dfcdae138613adbed28b84",
         "/app/forms/decidim/consultations/vote_form.rb" => "d2b69f479b61b32faf3b108da310081a",
         "/app/forms/decidim/consultations/multi_vote_form.rb" => "fc2160f0b5e85c9944d652b568c800f3"

--- a/spec/models/decidim/consultations/question_spec.rb
+++ b/spec/models/decidim/consultations/question_spec.rb
@@ -9,8 +9,12 @@ module Decidim
 
       let(:consultation) { create :consultation, :published, :active }
       let(:question) { create :question, consultation: consultation }
-      let(:response) { create :response, question: question }
-      let!(:vote) { create :vote, question: question, response: response }
+      let(:responses) { create_list :response, 3, question: question }
+      let!(:votes) do
+        responses.map.with_index do |response, index|
+          create_list :vote, index + 1, question: question, response: response
+        end.flatten
+      end
 
       it { is_expected.to be_publishable_results }
 
@@ -20,6 +24,33 @@ module Decidim
         end
 
         it { is_expected.not_to be_publishable_results }
+      end
+
+      describe "#weighted_responses" do
+        it "groups responses by question and calculates their weight" do
+          expect(question.weighted_responses[question.id].map(&:votes_count)).to match_array([1, 2, 3])
+        end
+      end
+
+      describe "#total_weighted_votes" do
+        it "returns the total weighted vote count for the question" do
+          # The total number of votes = 1 + 2 + 3
+          expect(question.total_weighted_votes).to eq(6)
+        end
+      end
+
+      describe "#most_weighted_voted_response" do
+        it "returns the response with the highest weighted vote count" do
+          # The response with the highest vote count has 3 votes
+          expect(question.most_weighted_voted_response.votes_count).to eq(3)
+        end
+      end
+
+      describe "#responses_sorted_by_weighted_votes" do
+        it "returns responses sorted by descending weighted vote count" do
+          sorted_votes_counts = question.responses_sorted_by_weighted_votes[question.id].map(&:votes_count)
+          expect(sorted_votes_counts).to eq([3, 2, 1])
+        end
       end
     end
   end

--- a/spec/system/decidim/action_delegator/weighted_results_spec.rb
+++ b/spec/system/decidim/action_delegator/weighted_results_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Weighted results", type: :system do
+  let(:organization) { create :organization, available_locales: [:en] }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let(:consultation) { create(:consultation, :finished, :published_results, organization: organization) }
+  let!(:question) { create(:question, consultation: consultation) }
+  let!(:responses) do
+    Array.new(2) { |i| create(:response, question: question, title: { "en" => "Option #{i + 1} Title" }) }
+  end
+
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+
+  let(:setting) { create(:setting, consultation: consultation) }
+  let(:ponderation1) { create(:ponderation, setting: setting, name: "consumer", weight: 4) }
+
+  before do
+    # Regular vote
+    question.votes.create(author: user, response: responses.first)
+    # Vote of a user with membership
+    question.votes.create(author: other_user, response: responses.last)
+
+    create(:participant, setting: setting, decidim_user: other_user, ponderation: ponderation1)
+
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_consultations.consultation_path(consultation)
+  end
+
+  it "displays weighted results" do
+    expect(page).to have_content("Option 2")
+    expect(page).to have_content("4 votes out of 5")
+  end
+
+  context "when visiting the question page" do
+    before do
+      visit decidim_consultations.question_path(question)
+    end
+
+    it "displays weighted results" do
+      within first(".card--list__item") do
+        expect(page).to have_content("Option 2")
+        expect(page).to have_content(4)
+      end
+
+      within all(".card--list__item")[1] do
+        expect(page).to have_content("Option 1")
+        expect(page).to have_content(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #170 

**Description:**

Implemented the display of weighted voting results in the public interface, ensuring the winning option shown is the true winner based on the weighted votes. This corrects the previous issue where results didn't reflect the actual impact of certain votes.

**Changes:**

- [x] Added weighted sum calculation for votes.
- [x] Updated public results display to reflect weighted outcomes.

**Screenshots:**

![Screenshot 2024-03-06 at 13 26 24](https://github.com/coopdevs/decidim-module-action_delegator/assets/60363870/f749ff42-5dad-4169-b5f9-9ea560e24605)
![Screenshot 2024-03-06 at 13 26 41](https://github.com/coopdevs/decidim-module-action_delegator/assets/60363870/96d62b3a-db97-465c-b80b-d24c0c4e048a)

