### PR TITLE
Display delegations buttons in mobile views

### DIFF
--- a/app/views/decidim/action_delegator/elections/_delegation_buttons.html.erb
+++ b/app/views/decidim/action_delegator/elections/_delegation_buttons.html.erb
@@ -1,5 +1,18 @@
 <% delegations = delegations_for(election, current_user) %>
 <% if delegations.any? %>
+  <div class="block order-first lg:hidden"> 
+    <button data-dialog-open="view-delegations" class="button button__lg button__transparent-secondary">
+      <%= t("decidim.action_delegator.elections.delegation_buttons.delegations_mobile_button") %>
+    </button>
+    <%= decidim_modal id: "view-delegations" do %>
+      <% if election.per_question? %>
+        <%= render "decidim/action_delegator/elections/per_question_buttons", delegations: %>
+      <% else %>
+        <%= render "decidim/action_delegator/elections/normal_election_buttons", delegations: %>
+      <% end %>
+    <% end %>
+  </div>
+
   <div class="election__aside-voted mt-6 hidden lg:block">
     <% if election.per_question? %>
       <%= render "decidim/action_delegator/elections/per_question_buttons", delegations: %>

--- a/app/views/decidim/action_delegator/elections/_delegation_buttons.html.erb
+++ b/app/views/decidim/action_delegator/elections/_delegation_buttons.html.erb
@@ -1,6 +1,6 @@
 <% delegations = delegations_for(election, current_user) %>
 <% if delegations.any? %>
-  <div class="block order-first lg:hidden"> 
+  <div class="block order-first lg:hidden">
     <button data-dialog-open="view-delegations" class="button button__lg button__transparent-secondary">
       <%= t("decidim.action_delegator.elections.delegation_buttons.delegations_mobile_button") %>
     </button>

--- a/app/views/decidim/action_delegator/elections/_normal_election_buttons.html.erb
+++ b/app/views/decidim/action_delegator/elections/_normal_election_buttons.html.erb
@@ -6,7 +6,7 @@
       ✔ <%= t("decidim.action_delegator.elections.delegation_buttons.vote_for", name: delegation.granter.name) %>
     <% end %>
   <% else %>
-    <%= link_to new_election_vote_path(election, delegation: delegation.id), class: "button button__primary button__lg" do %>
+    <%= link_to new_election_vote_path(election, delegation: delegation.id), class: "button button__primary button__lg mb-4" do %>
       👉 <%= t("decidim.action_delegator.elections.delegation_buttons.vote_for", name: delegation.granter.name) %>
     <% end %>
   <% end %>

--- a/app/views/decidim/action_delegator/elections/_normal_election_buttons.html.erb
+++ b/app/views/decidim/action_delegator/elections/_normal_election_buttons.html.erb
@@ -2,7 +2,7 @@
 
 <% delegations.each do |delegation| %>
   <% if participant_voted?(election, delegation.granter) %>
-    <%= link_to new_election_vote_path(election, delegation: delegation.id), class: "button button__secondary button__lg" do %>
+    <%= link_to new_election_vote_path(election, delegation: delegation.id), class: "button button__secondary button__lg mb-4" do %>
       ✔ <%= t("decidim.action_delegator.elections.delegation_buttons.vote_for", name: delegation.granter.name) %>
     <% end %>
   <% else %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -356,6 +356,7 @@ ca:
                 mostren al públic.</p>"
         delegation_buttons:
           delegations_active: Teniu vots delegats.
+          delegations_mobile_button: Vots delegats
           per_question_delegations: 'Podeu votar en nom dels següents participants
             en aquesta elecció:'
           vote_for: Vota en nom de %{name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,6 +352,7 @@ en:
                 for each option.</p> <p>⚠️ These results are not shown to the public.</p>"
         delegation_buttons:
           delegations_active: You have delegated votes.
+          delegations_mobile_button: Delegated votes
           per_question_delegations: 'You can vote on behalf of the following participants
             in this election:'
           vote_for: Vote on behalf of %{name}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -360,6 +360,7 @@ es:
                 al público.</p>"
         delegation_buttons:
           delegations_active: Tienes votos delegados.
+          delegations_mobile_button: Votos delegados
           per_question_delegations: 'Puedes votar en nombre de los siguientes participantes
             en esta elección:'
           vote_for: Votar en nombre de %{name}

--- a/spec/system/decidim/action_delegator/delegations_multiple_spec.rb
+++ b/spec/system/decidim/action_delegator/delegations_multiple_spec.rb
@@ -106,5 +106,30 @@ describe "Delegation vote in elections" do
         end
       end
     end
+
+    context "when viewing on a mobile browser" do
+      before do
+        driven_by(:iphone)
+        create(:authorization, :granted, user:, name: "delegations_verifier", metadata: { setting_id: setting.id })
+        visit election_path
+        click_on "Accept all"
+      end
+
+      it "shows the delegation sticky button on mobile" do
+        expect(page).to have_css("button[data-dialog-open='view-delegations']", visible: :visible)
+      end
+
+      it "hides the desktop delegation section on mobile" do
+        expect(page).to have_no_css(".election__aside-voted", visible: :visible)
+      end
+
+      it "opens the delegation modal when clicking the button" do
+        click_on I18n.t("decidim.action_delegator.elections.delegation_buttons.delegations_mobile_button")
+
+        expect(page).to have_content(
+          I18n.t("decidim.action_delegator.elections.delegation_buttons.delegations_active")
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
🎩 What? Why?
With this PR delegations buttons will display in mobile views.

📌 Related Issues
Link your PR to an issue
Related to #?
Fixes #207 

📷 Screenshots
<img width="378" height="623" alt="image" src="https://github.com/user-attachments/assets/ac146d39-99f9-4a53-8780-4256d2d32ba3" />
delegated votes mobile button
<img width="378" height="623" alt="image" src="https://github.com/user-attachments/assets/c8fe75dd-b52e-4fdb-95ea-a0f394b5b062" />
delegated votes modal in mobile

♥️ Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized delegation UI: sticky delegations button and modal for viewing/managing delegated votes; desktop sidebar hidden on mobile.

* **Style**
  * Added extra vertical spacing for delegation action buttons for improved readability.

* **Tests**
  * System test added to verify mobile delegation button visibility, modal behavior, and desktop sidebar absence on mobile.

* **Localization**
  * New translations for the mobile delegations button (EN/ES/CA).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openpoke/decidim-module-action_delegator/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->